### PR TITLE
Add Helm chart + Dockerfiles to self-host the Lolly product

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Keep Docker build contexts lean and reproducible. The build stages run their
+# OWN `npm ci` and `npm run build:web`, so never ship host build artifacts.
+.git
+node_modules
+**/node_modules
+shells/web/dist
+dist
+scratch
+plans
+tests
+.vercel
+**/.vercel
+.DS_Store
+**/.DS_Store
+*.log
+npm-debug.log*
+.env
+.env.*
+**/.env
+**/.env.*
+services/ca/.env

--- a/deploy/docker/ca.Dockerfile
+++ b/deploy/docker/ca.Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+# ============================================================================
+# Lolly CA — OIDC-verified short-lived X.509 leaf issuance for C2PA signing.
+# ============================================================================
+# Runs `node services/ca/server.mjs`. Listens on $PORT (default 8787), serving
+# under /api/ca (GET /api/ca/health, GET /api/ca/root.pem, the OAuth auth/callback
+# routes, POST /api/ca/enroll). Stateless — the only state is the root key/cert
+# supplied via env; issuance logs are POSTed to an optional webhook.
+#
+# BUILD CONTEXT MUST BE THE REPO ROOT — the handler imports engine/src/x509.ts
+# by relative path (../../../engine/src/x509.ts):
+#
+#   docker build -f deploy/docker/ca.Dockerfile -t <registry>/lolly-ca:0.1.0 .
+#
+# REQUIRED runtime env (see services/ca/.env.example): CA_SERVICE_SECRET,
+# CA_ROOT_KEY_PEM, CA_ROOT_CERT_PEM, CA_ALLOWED_ORIGINS, plus at least one OIDC
+# provider pair (GITHUB_*, GOOGLE_*, SUSE_*). Generate the root once with
+# `node services/ca/scripts/gen-root.mjs`. Without the root + secret, /enroll and
+# auth fail (health still answers). The Helm chart wires these from a Secret.
+# ============================================================================
+
+FROM node:24-bookworm-slim AS build
+WORKDIR /src
+ENV NODE_ENV=production
+
+COPY . .
+
+# CA itself is zero-dependency, but it lives in the workspace and imports the
+# engine sibling, so install the workspace graph (runtime deps only).
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+RUN npm ci --omit=dev --no-audit --no-fund
+
+# ── runtime stage ───────────────────────────────────────────────────────────
+FROM node:24-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=8787
+
+COPY --from=build /src /app
+
+USER node
+EXPOSE 8787
+
+CMD ["node", "services/ca/server.mjs"]

--- a/deploy/docker/mcp.Dockerfile
+++ b/deploy/docker/mcp.Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1
+# ============================================================================
+# Lolly MCP server — the one hosted service (opt-in).
+# ============================================================================
+# Streamable-HTTP MCP transport + OAuth discovery. Runs `node services/mcp/src/http.ts`
+# (Node 24 executes TypeScript natively — no compile step). Listens on $PORT
+# (default 8790), serving JSON-RPC at POST /mcp plus the .well-known OAuth routes
+# and a public GET render path (/tool/<id>.<ext>). Stateless (SSE/session mgmt is
+# roadmap), so it scales horizontally.
+#
+# BUILD CONTEXT MUST BE THE REPO ROOT — the server imports its sibling workspace
+# (@lolly/engine at ../../../engine) and, at runtime, loads tools from the
+# repo-root tools/ + catalog/ profile views:
+#
+#   docker build -f deploy/docker/mcp.Dockerfile -t <registry>/lolly-mcp:0.1.0 .
+#
+# The tools/ + catalog/ content is baked at build time from LOLLY_PROFILE (as with
+# the web image), so the running container needs no pack mount. Requires the
+# content submodules (community/, brands/*) checked out in the build context.
+#
+# Tier-B (browser/Chromium) render formats are DISABLED unless LOLLY_WEB_BASE is
+# set at runtime; svg/data + resvg-png work without a browser. We deliberately do
+# NOT install Playwright's Chromium here to keep the image slim — set env
+# LOLLY_WEB_BASE=https://<your-web-host> to point at your web deployment's
+# renderer instead.
+# ============================================================================
+
+FROM node:24-bookworm-slim AS build
+WORKDIR /src
+ARG LOLLY_PROFILE=suse
+ENV LOLLY_PROFILE=${LOLLY_PROFILE}
+ENV NODE_ENV=production
+
+COPY . .
+
+# Runtime deps only (omit dev). postinstall materialises the tools/ + catalog/
+# views for LOLLY_PROFILE. PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD keeps the optional
+# playwright-core from fetching a browser we don't ship.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+RUN npm ci --omit=dev --no-audit --no-fund
+
+# ── runtime stage ───────────────────────────────────────────────────────────
+FROM node:24-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+# Default transport port; the chart sets PORT explicitly too.
+ENV PORT=8790
+
+# Bring the installed monorepo across whole — the .ts entrypoint resolves engine
+# and tool/catalog paths by relative position, so the layout must be preserved.
+COPY --from=build /src /app
+
+# node:*-slim ships a non-root `node` user (uid 1000).
+USER node
+EXPOSE 8790
+
+# `npm run mcp:http` → node services/mcp/src/http.ts (startHttpServer()).
+CMD ["node", "services/mcp/src/http.ts"]

--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -1,0 +1,98 @@
+# ============================================================================
+# Lolly Web PWA — nginx server config (nginx-unprivileged, non-root, :8080).
+# ============================================================================
+# Serves the static SPA/PWA in /usr/share/nginx/html with:
+#   - SPA fallback that also resolves the build's .html multi-page views
+#   - long immutable caching for hashed /assets/, short/no-cache for the shell
+#   - never-cache the service worker (sw.js) and index.html
+#   - correct MIME for .wasm / .avif / .webmanifest
+#   - a cheap /healthz for k8s probes
+# Mirrors the production Vercel rewrites in shells/web/vercel.json.
+# ============================================================================
+
+# Explicit types for assets stock mime.types may miss on older nginx builds.
+types {
+    application/wasm                      wasm;
+    image/avif                            avif;
+    image/webp                            webp;
+    application/manifest+json             webmanifest;
+    model/gltf-binary                     glb;
+    font/woff2                            woff2;
+}
+
+server {
+    # nginx-unprivileged cannot bind <1024; 8080 is the image default.
+    listen       8080;
+    listen       [::]:8080;
+    server_name  _;
+
+    root   /usr/share/nginx/html;
+    index  index.html;
+
+    # Absolute-path assets are large binaries (wasm, fonts, onnx models); let
+    # nginx stream them and keep gzip for text.
+    gzip              on;
+    gzip_vary         on;
+    gzip_min_length   1024;
+    gzip_proxied      any;
+    gzip_types        text/plain text/css application/javascript application/json
+                      image/svg+xml application/manifest+json application/wasm;
+
+    # Liveness/readiness — cheap, unauthenticated, no filesystem lookup.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+
+    # ── Service worker: MUST never be cached, and may control the whole scope.
+    location = /sw.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Service-Worker-Allowed "/";
+    }
+
+    # ── App shell + PWA manifest: revalidate every load so deploys take effect.
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+    location = /manifest.webmanifest {
+        add_header Cache-Control "no-cache";
+        default_type application/manifest+json;
+    }
+
+    # ── Content-hashed build output: safe to cache forever (immutable).
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # ── ONNX runtime wasm/glue + models: hashed by upstream, cache long.
+    location /ort/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+    location /models/ {
+        add_header Cache-Control "public, max-age=604800";
+        try_files $uri =404;
+    }
+
+    # ── Fonts: long cache.
+    location /fonts/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # ── Short URL aliases the SPA expects (parity with vercel.json rewrites).
+    location = /d       { try_files /view/d.html =404; }
+    location = /v       { try_files /view/v.html =404; }
+    location = /c       { try_files /view/c.html =404; }
+    location = /p       { try_files /view/p.html =404; }
+    location = /profile { try_files /view/profile.html =404; }
+
+    # ── Everything else: serve the file, then its .html twin, then a directory
+    # index, then fall back to the SPA shell. Covers /t/<id> → /t/<id>.html and
+    # /info/* real pages while keeping client-routed paths on index.html.
+    location / {
+        try_files $uri $uri.html $uri/index.html /index.html;
+    }
+}

--- a/deploy/docker/web.Dockerfile
+++ b/deploy/docker/web.Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1
+# ============================================================================
+# Lolly Web PWA — the primary self-hosted product.
+# ============================================================================
+# Multi-stage: a Node build stage runs the real `npm run build:web` and a tiny
+# nginx-unprivileged stage serves the resulting static `shells/web/dist`.
+#
+# BUILD CONTEXT MUST BE THE REPO ROOT (not deploy/docker):
+#
+#   docker build -f deploy/docker/web.Dockerfile -t <registry>/lolly-web:0.1.0 .
+#
+# The build bakes ONE brand/profile into the static output (theme-color, PWA
+# chrome, and the copied tools/ + catalog/ content are resolved at build time by
+# scripts/use-profile.ts + the vite brandChrome plugin — see shells/web/vite.config.js).
+# Choose it with --build-arg LOLLY_PROFILE=suse|lolly-start (default: suse). The
+# resulting image is fully self-contained — nothing is read at serve time, so the
+# Helm chart needs NO runtime pack/brand mount for the web app.
+#
+# REQUIREMENT: the repo's content submodules (community/, brands/*) must be
+# checked out in the build context — `npm run build:web` dereferences the
+# tools/ + catalog/ profile views into dist. A bare checkout without submodules
+# will build a shell with an empty catalog.
+# ============================================================================
+
+# ── build stage ─────────────────────────────────────────────────────────────
+FROM node:24-bookworm AS build
+WORKDIR /src
+
+# Which brand/profile to bake into the static build (see header).
+ARG LOLLY_PROFILE=suse
+ENV LOLLY_PROFILE=${LOLLY_PROFILE}
+ENV NODE_ENV=production
+# Native optional deps (sharp/onnxruntime/resvg/playwright) need dev tooling
+# absent from the slim variant; bookworm carries what node-gyp/prebuilt need.
+
+# Copy the whole monorepo — build:web spans root scripts, engine, docs, the
+# web shell, and the profile content packs. A narrower copy breaks the workspace
+# graph, so we copy everything (respecting .dockerignore).
+COPY . .
+
+# Full install (build:web needs devDeps: vite, esbuild, sharp, onnxruntime-node,
+# svgo, resvg). `postinstall` runs scripts/use-profile.ts --auto to materialise
+# the tools/ + catalog/ views for LOLLY_PROFILE. Use --no-audit --no-fund for a
+# quiet, reproducible install.
+RUN npm ci --no-audit --no-fund
+
+# Produce shells/web/dist (build:ort → build:info → OG images → vite build).
+RUN npm run build:web
+
+# ── runtime stage ───────────────────────────────────────────────────────────
+# nginx-unprivileged runs as uid 101 (non-root) and listens on 8080 by default.
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
+
+# Our server config replaces the stock default.conf.
+COPY deploy/docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Static site. nginx-unprivileged serves from /usr/share/nginx/html.
+COPY --from=build /src/shells/web/dist /usr/share/nginx/html
+
+# nginx-unprivileged already sets USER 101 and a RuntimeDefault-friendly layout.
+EXPOSE 8080
+# The base image's entrypoint launches nginx in the foreground.

--- a/deploy/helm/.helmignore
+++ b/deploy/helm/.helmignore
@@ -1,0 +1,15 @@
+# Patterns to ignore when packaging the chart (helm package / helm install .).
+.DS_Store
+.git/
+.gitignore
+*.tmproj
+*.bak
+*.orig
+*.swp
+*~
+.idea/
+.vscode/
+# Never bundle real config or secrets into the chart archive.
+*.env
+.env
+values-*.yaml

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: lolly
+description: >-
+  Self-host Lolly — the constraint-first, template-driven asset generation PWA.
+  The `web` component (on by default) serves the offline-capable web app your
+  employees open at a URL: 2 stateless HA replicas behind nginx, nothing to
+  configure. Two opt-in HTTP services ride alongside: `mcp` (the hosted MCP
+  server for AI agents) and `ca` (the C2PA credential authority). One values
+  file, secure defaults, no external prerequisites beyond a cluster.
+type: application
+
+# Chart version — bump on any change to templates/values (SemVer for the chart).
+version: 0.1.0
+
+# The Lolly release these images are built against. Used as the default image
+# tag when a component's image.tag is left empty. Keep in sync with the repo's
+# package.json "version".
+appVersion: "0.1.0"
+
+home: https://lolly.tools
+sources:
+  - https://github.com/lolly-tools/lolly
+keywords:
+  - lolly
+  - pwa
+  - asset-generation
+  - mcp
+  - c2pa
+maintainers:
+  - name: Lolly

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -1,0 +1,67 @@
+lolly {{ .Chart.AppVersion }} — release "{{ .Release.Name }}" installed in namespace "{{ .Release.Namespace }}".
+
+Components:
+{{- if .Values.web.enabled }}
+  web  (ON)   {{ include "lolly.componentImage" (dict "image" .Values.web.image "root" .) }}   — {{ .Values.web.replicaCount }} replica(s), stateless static PWA
+{{- else }}
+  web  (off)  — the primary product is disabled; nothing serves the app URL.
+{{- end }}
+  mcp  ({{ if .Values.mcp.enabled }}ON{{ else }}off{{ end }}){{ if .Values.mcp.enabled }}   {{ include "lolly.componentImage" (dict "image" .Values.mcp.image "root" .) }}   — hosted MCP server{{ end }}
+  ca   ({{ if .Values.ca.enabled }}ON{{ else }}off{{ end }}){{ if .Values.ca.enabled }}   {{ include "lolly.componentImage" (dict "image" .Values.ca.image "root" .) }}   — C2PA credential authority{{ end }}
+
+★ THE WEB APP IS THE PRIMARY URL you give employees — the offline-capable Lolly
+  PWA. The mcp and ca services are opt-in backends; most installs only need web.
+
+{{- if .Values.web.enabled }}
+
+Reach the web app:
+{{- if .Values.web.ingress.enabled }}
+{{- range .Values.web.ingress.hosts }}
+  http{{ if $.Values.web.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+  No ingress yet. Try it with a port-forward:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "lolly.componentFullname" (dict "root" . "name" "web") }} 8080:{{ .Values.web.service.port }}
+  then open http://localhost:8080/
+  To publish it, set web.ingress.enabled=true and web.ingress.hosts[0].host.
+{{- end }}
+
+  The brand/catalog is baked into the web image at build time — there is nothing
+  to mount or configure at runtime. To change brand, rebuild the image with a
+  different --build-arg LOLLY_PROFILE and roll the deployment.
+{{- else }}
+
+WARNING: web.enabled=false — no one can open the Lolly app. Set web.enabled=true
+(the default) unless you are deliberately running backends only.
+{{- end }}
+
+{{- if .Values.mcp.enabled }}
+
+MCP server:
+{{- if .Values.mcp.ingress.enabled }}
+{{- range .Values.mcp.ingress.hosts }}
+  http{{ if $.Values.mcp.ingress.tls }}s{{ end }}://{{ .host }}/mcp
+{{- end }}
+{{- else }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "lolly.componentFullname" (dict "root" . "name" "mcp") }} 8790:{{ .Values.mcp.service.port }}
+{{- end }}
+{{- if not .Values.mcp.webBase }}
+  Note: mcp.webBase is unset — Tier-B (browser) render formats are disabled;
+  svg/data + resvg-png still work. Set mcp.webBase to your web host to enable them.
+{{- end }}
+{{- end }}
+
+{{- if .Values.ca.enabled }}
+
+CA service (health at /api/ca/health):
+{{- if .Values.ca.ingress.enabled }}
+{{- range .Values.ca.ingress.hosts }}
+  http{{ if $.Values.ca.ingress.tls }}s{{ end }}://{{ .host }}/api/ca/health
+{{- end }}
+{{- else }}
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "lolly.componentFullname" (dict "root" . "name" "ca") }} 8787:{{ .Values.ca.service.port }}
+{{- end }}
+  Secrets: {{ if .Values.ca.existingSecret }}existing secret "{{ .Values.ca.existingSecret }}" (Mode B){{ else }}chart-managed secret "{{ include "lolly.ca.secretName" . }}" (Mode A){{ end }}.
+  Ensure ca.config.allowedOrigins includes your web host, or enrollment tokens
+  are rejected.
+{{- end }}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,87 @@
+{{/*
+Base name of the chart.
+*/}}
+{{- define "lolly.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Release-scoped base fullname (DNS-safe, <=63 chars).
+*/}}
+{{- define "lolly.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "lolly.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Per-component fullname: "<release-fullname>-<component>" (e.g. lolly-web).
+Usage: {{ include "lolly.componentFullname" (dict "root" . "name" "web") }}
+*/}}
+{{- define "lolly.componentFullname" -}}
+{{- printf "%s-%s" (include "lolly.fullname" .root) .name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels for a component. Pass (dict "root" . "name" "<component>").
+*/}}
+{{- define "lolly.componentLabels" -}}
+helm.sh/chart: {{ include "lolly.chart" .root }}
+{{ include "lolly.componentSelectorLabels" . }}
+{{- if .root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+app.kubernetes.io/part-of: {{ include "lolly.name" .root }}
+{{- end }}
+
+{{/*
+Selector labels for a component (stable — never include version/checksum).
+*/}}
+{{- define "lolly.componentSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "lolly.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .name }}
+{{- end }}
+
+{{/*
+Image reference for a component. Pass (dict "image" .Values.web.image "root" .).
+tag defaults to the chart appVersion.
+*/}}
+{{- define "lolly.componentImage" -}}
+{{- $tag := default .root.Chart.AppVersion .image.tag -}}
+{{- printf "%s:%s" .image.repository $tag -}}
+{{- end }}
+
+{{/*
+Shared ServiceAccount name.
+*/}}
+{{- define "lolly.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "lolly.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+CA Secret name — the existing secret if provided, else the chart-managed one.
+*/}}
+{{- define "lolly.ca.secretName" -}}
+{{- if .Values.ca.existingSecret }}
+{{- .Values.ca.existingSecret }}
+{{- else }}
+{{- printf "%s-secrets" (include "lolly.componentFullname" (dict "root" . "name" "ca")) }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/ca-deployment.yaml
+++ b/deploy/helm/templates/ca-deployment.yaml
@@ -1,0 +1,163 @@
+{{- if .Values.ca.enabled -}}
+{{- $c := .Values.ca -}}
+{{- $labels := dict "root" . "name" "ca" -}}
+{{- $secretName := include "lolly.ca.secretName" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lolly.componentFullname" $labels }}
+  labels:
+    {{- include "lolly.componentLabels" $labels | nindent 4 }}
+spec:
+  replicas: {{ $c.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lolly.componentSelectorLabels" $labels | nindent 6 }}
+  template:
+    metadata:
+      {{- with $c.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "lolly.componentSelectorLabels" $labels | nindent 8 }}
+        {{- with $c.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lolly.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if $c.affinity }}
+      affinity:
+        {{- toYaml $c.affinity | nindent 8 }}
+      {{- else if eq $c.podAntiAffinity "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- include "lolly.componentSelectorLabels" $labels | nindent 18 }}
+              topologyKey: kubernetes.io/hostname
+      {{- else if eq $c.podAntiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "lolly.componentSelectorLabels" $labels | nindent 20 }}
+                topologyKey: kubernetes.io/hostname
+      {{- end }}
+      {{- with $c.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $c.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $c.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: ca
+          image: {{ include "lolly.componentImage" (dict "image" $c.image "root" .) }}
+          imagePullPolicy: {{ $c.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ $c.service.targetPort }}
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: {{ $c.service.targetPort | quote }}
+            # ── Non-secret CA config ──────────────────────────────────────────
+            {{- with $c.config.allowedOrigins }}
+            - name: CA_ALLOWED_ORIGINS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $c.config.githubClientId }}
+            - name: GITHUB_CLIENT_ID
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $c.config.googleClientId }}
+            - name: GOOGLE_CLIENT_ID
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $c.config.suseIssuer }}
+            - name: SUSE_ISSUER
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $c.config.suseClientId }}
+            - name: SUSE_CLIENT_ID
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $c.config.certDays }}
+            - name: CA_CERT_DAYS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $c.config.certMaxDays }}
+            - name: CA_CERT_MAX_DAYS
+              value: {{ . | quote }}
+            {{- end }}
+            # ── Secret-backed env (chart-managed or existingSecret) ───────────
+            - name: CA_SERVICE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: CA_SERVICE_SECRET
+            - name: CA_ROOT_KEY_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: CA_ROOT_KEY_PEM
+            - name: CA_ROOT_CERT_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: CA_ROOT_CERT_PEM
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: GITHUB_CLIENT_SECRET
+                  optional: true
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: GOOGLE_CLIENT_SECRET
+                  optional: true
+            - name: SUSE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: SUSE_CLIENT_SECRET
+                  optional: true
+            {{- with $c.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml $c.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml $c.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml $c.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/deploy/helm/templates/ca-secret.yaml
+++ b/deploy/helm/templates/ca-secret.yaml
@@ -1,0 +1,31 @@
+{{- /*
+Chart-managed CA Secret (Mode A). Skipped when ca.existingSecret is set (Mode B).
+Holds the root key/cert, the service HMAC secret, and any confidential OIDC
+client secrets. For production prefer Mode B from your platform's secret store.
+*/ -}}
+{{- if and .Values.ca.enabled (not .Values.ca.existingSecret) -}}
+{{- $s := .Values.ca.secrets -}}
+{{- if not $s.serviceSecret }}{{ fail "ca.secrets.serviceSecret is required when ca.enabled and no ca.existingSecret (openssl rand -hex 32)" }}{{ end }}
+{{- if not $s.rootKeyPem }}{{ fail "ca.secrets.rootKeyPem is required when ca.enabled and no ca.existingSecret (node services/ca/scripts/gen-root.mjs)" }}{{ end }}
+{{- if not $s.rootCertPem }}{{ fail "ca.secrets.rootCertPem is required when ca.enabled and no ca.existingSecret (node services/ca/scripts/gen-root.mjs)" }}{{ end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "lolly.ca.secretName" . }}
+  labels:
+    {{- include "lolly.componentLabels" (dict "root" . "name" "ca") | nindent 4 }}
+type: Opaque
+stringData:
+  CA_SERVICE_SECRET: {{ $s.serviceSecret | quote }}
+  CA_ROOT_KEY_PEM: {{ $s.rootKeyPem | quote }}
+  CA_ROOT_CERT_PEM: {{ $s.rootCertPem | quote }}
+  {{- with $s.githubClientSecret }}
+  GITHUB_CLIENT_SECRET: {{ . | quote }}
+  {{- end }}
+  {{- with $s.googleClientSecret }}
+  GOOGLE_CLIENT_SECRET: {{ . | quote }}
+  {{- end }}
+  {{- with $s.suseClientSecret }}
+  SUSE_CLIENT_SECRET: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/templates/ca-service.yaml
+++ b/deploy/helm/templates/ca-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.ca.enabled -}}
+{{- $labels := dict "root" . "name" "ca" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lolly.componentFullname" $labels }}
+  labels:
+    {{- include "lolly.componentLabels" $labels | nindent 4 }}
+spec:
+  type: {{ .Values.ca.service.type }}
+  ports:
+    - port: {{ .Values.ca.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lolly.componentSelectorLabels" $labels | nindent 4 }}
+{{- end }}

--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -1,0 +1,47 @@
+{{- /*
+One Ingress per component whose <component>.enabled AND <component>.ingress.enabled
+are both true. Kept in a single file so the routing for the whole release is
+visible at a glance.
+*/ -}}
+{{- range $name := (list "web" "mcp" "ca") }}
+{{- $c := index $.Values $name }}
+{{- if and $c.enabled $c.ingress.enabled }}
+{{- $labels := dict "root" $ "name" $name }}
+{{- $fullName := include "lolly.componentFullname" $labels }}
+{{- $svcPort := $c.service.port }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "lolly.componentLabels" $labels | nindent 4 }}
+  {{- with $c.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $c.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with $c.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range $c.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/mcp-deployment.yaml
+++ b/deploy/helm/templates/mcp-deployment.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.mcp.enabled -}}
+{{- $c := .Values.mcp -}}
+{{- $labels := dict "root" . "name" "mcp" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lolly.componentFullname" $labels }}
+  labels:
+    {{- include "lolly.componentLabels" $labels | nindent 4 }}
+spec:
+  replicas: {{ $c.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lolly.componentSelectorLabels" $labels | nindent 6 }}
+  template:
+    metadata:
+      {{- with $c.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "lolly.componentSelectorLabels" $labels | nindent 8 }}
+        {{- with $c.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lolly.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if $c.affinity }}
+      affinity:
+        {{- toYaml $c.affinity | nindent 8 }}
+      {{- else if eq $c.podAntiAffinity "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- include "lolly.componentSelectorLabels" $labels | nindent 18 }}
+              topologyKey: kubernetes.io/hostname
+      {{- else if eq $c.podAntiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "lolly.componentSelectorLabels" $labels | nindent 20 }}
+                topologyKey: kubernetes.io/hostname
+      {{- end }}
+      {{- with $c.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $c.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $c.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: mcp
+          image: {{ include "lolly.componentImage" (dict "image" $c.image "root" .) }}
+          imagePullPolicy: {{ $c.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ $c.service.targetPort }}
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: {{ $c.service.targetPort | quote }}
+            {{- with $c.webBase }}
+            - name: LOLLY_WEB_BASE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with $c.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $c.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml $c.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml $c.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml $c.resources | nindent 12 }}
+          volumeMounts:
+            # Writable /tmp under the read-only root filesystem.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/deploy/helm/templates/mcp-service.yaml
+++ b/deploy/helm/templates/mcp-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.mcp.enabled -}}
+{{- $labels := dict "root" . "name" "mcp" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lolly.componentFullname" $labels }}
+  labels:
+    {{- include "lolly.componentLabels" $labels | nindent 4 }}
+spec:
+  type: {{ .Values.mcp.service.type }}
+  ports:
+    - port: {{ .Values.mcp.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lolly.componentSelectorLabels" $labels | nindent 4 }}
+{{- end }}

--- a/deploy/helm/templates/networkpolicy.yaml
+++ b/deploy/helm/templates/networkpolicy.yaml
@@ -1,0 +1,45 @@
+{{- /*
+Optional NetworkPolicy per enabled component. Restricts ingress to that
+component's HTTP port; egress is left open by default so the MCP/CA services can
+reach IdPs and providers. Enable cluster-wide with networkPolicy.enabled=true.
+*/ -}}
+{{- if .Values.networkPolicy.enabled -}}
+{{- range $name := (list "web" "mcp" "ca") }}
+{{- $c := index $.Values $name }}
+{{- if $c.enabled }}
+{{- $labels := dict "root" $ "name" $name }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "lolly.componentFullname" $labels }}
+  labels:
+    {{- include "lolly.componentLabels" $labels | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "lolly.componentSelectorLabels" $labels | nindent 6 }}
+  policyTypes:
+    - Ingress
+    {{- if not $.Values.networkPolicy.allowAllEgress }}
+    - Egress
+    {{- end }}
+  ingress:
+    - from:
+        {{- if $.Values.networkPolicy.ingressNamespaceSelector }}
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml $.Values.networkPolicy.ingressNamespaceSelector | nindent 14 }}
+        {{- else }}
+        - podSelector: {}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ $c.service.targetPort }}
+  {{- if $.Values.networkPolicy.allowAllEgress }}
+  egress:
+    - {}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/serviceaccount.yaml
+++ b/deploy/helm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lolly.serviceAccountName" . }}
+  labels:
+    {{- include "lolly.componentLabels" (dict "root" . "name" "shared") | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/helm/templates/web-deployment.yaml
+++ b/deploy/helm/templates/web-deployment.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.web.enabled -}}
+{{- $c := .Values.web -}}
+{{- $labels := dict "root" . "name" "web" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lolly.componentFullname" $labels }}
+  labels:
+    {{- include "lolly.componentLabels" $labels | nindent 4 }}
+spec:
+  replicas: {{ $c.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lolly.componentSelectorLabels" $labels | nindent 6 }}
+  template:
+    metadata:
+      {{- with $c.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "lolly.componentSelectorLabels" $labels | nindent 8 }}
+        {{- with $c.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lolly.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if $c.affinity }}
+      affinity:
+        {{- toYaml $c.affinity | nindent 8 }}
+      {{- else if eq $c.podAntiAffinity "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- include "lolly.componentSelectorLabels" $labels | nindent 18 }}
+              topologyKey: kubernetes.io/hostname
+      {{- else if eq $c.podAntiAffinity "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "lolly.componentSelectorLabels" $labels | nindent 20 }}
+                topologyKey: kubernetes.io/hostname
+      {{- end }}
+      {{- with $c.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $c.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $c.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: web
+          image: {{ include "lolly.componentImage" (dict "image" $c.image "root" .) }}
+          imagePullPolicy: {{ $c.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ $c.service.targetPort }}
+              protocol: TCP
+          {{- with $c.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml $c.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml $c.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml $c.resources | nindent 12 }}
+          volumeMounts:
+            # nginx-unprivileged needs writable temp/cache/run dirs under a
+            # read-only root filesystem. These emptyDirs satisfy that.
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /tmp
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+{{- end }}

--- a/deploy/helm/templates/web-service.yaml
+++ b/deploy/helm/templates/web-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.web.enabled -}}
+{{- $labels := dict "root" . "name" "web" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lolly.componentFullname" $labels }}
+  labels:
+    {{- include "lolly.componentLabels" $labels | nindent 4 }}
+spec:
+  type: {{ .Values.web.service.type }}
+  ports:
+    - port: {{ .Values.web.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lolly.componentSelectorLabels" $labels | nindent 4 }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,348 @@
+# ============================================================================
+# lolly — Helm values
+# ============================================================================
+# THIS IS THE ONE FILE YOU EDIT. Lolly's north star is "absolutely easy to
+# deploy": a Kubernetes cluster + a web image + this file is all it takes to
+# give your employees a URL to the offline-capable web app.
+#
+# Minimum viable install (just the web PWA, port-forward to try it):
+#
+#   helm install lolly deploy/helm \
+#     --set web.image.repository=<registry>/lolly-web
+#
+# Production install (web PWA on your own hostname, TLS via cert-manager):
+#
+#   helm install lolly deploy/helm \
+#     --set web.image.repository=<registry>/lolly-web \
+#     --set web.ingress.enabled=true \
+#     --set web.ingress.hosts[0].host=lolly.example.com \
+#     --set web.ingress.tls[0].secretName=lolly-web-tls \
+#     --set web.ingress.tls[0].hosts[0]=lolly.example.com
+#
+# The two backend services (mcp, ca) are OPT-IN and disabled by default — turn
+# them on only if you need the hosted MCP server or the C2PA credential
+# authority (see their sections far below).
+# ============================================================================
+
+# Applied to every component's resource names.
+nameOverride: ""
+fullnameOverride: ""
+
+# docker-registry pull secrets, if your images live in a private registry.
+# e.g.  [{ name: my-regcred }]
+imagePullSecrets: []
+
+# ── Shared ServiceAccount ───────────────────────────────────────────────────
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+  # These are plain static/HTTP services with no Kubernetes API needs.
+  automountServiceAccountToken: false
+
+# ════════════════════════════════════════════════════════════════════════════
+# web — THE PRIMARY PRODUCT (enabled by default)
+# ════════════════════════════════════════════════════════════════════════════
+# The Lolly PWA: a fully static, offline-capable SPA served by nginx. It holds
+# NO server-side state (everything runs client-side; data lives in the browser's
+# IndexedDB), so replicas are freely interchangeable and it scales trivially.
+#
+# The brand/catalog is BAKED INTO THE IMAGE at build time (theme, tools/, and
+# catalog/ are resolved by `npm run build:web` — see deploy/docker/web.Dockerfile
+# --build-arg LOLLY_PROFILE). The running container reads nothing at serve time,
+# so there is NOTHING to mount here — no pack, no config, no secret.
+web:
+  enabled: true
+
+  # 2 replicas for HA. Stateless static content — raise freely for more traffic.
+  replicaCount: 2
+
+  image:
+    # REQUIRED: build and push the web image, then set this repository.
+    #   docker build -f deploy/docker/web.Dockerfile \
+    #     --build-arg LOLLY_PROFILE=suse \
+    #     -t <registry>/lolly-web:0.1.0 .
+    #   docker push <registry>/lolly-web:0.1.0
+    repository: ghcr.io/lolly-tools/lolly-web
+    # Empty ⇒ use the chart's appVersion. Pin an immutable tag/digest in prod.
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 80
+    # Container port nginx-unprivileged listens on (see nginx.conf). Non-root
+    # nginx cannot bind <1024, so this is 8080, not 80.
+    targetPort: 8080
+
+  # TLS-ready ingress. Point config.instance is not needed — the PWA is origin-
+  # agnostic; just give it a hostname.
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+      # cert-manager.io/cluster-issuer: letsencrypt-prod
+    hosts:
+      - host: lolly.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+      # - secretName: lolly-web-tls
+      #   hosts:
+      #     - lolly.example.com
+
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 250m
+      memory: 128Mi
+
+  # nginx `/healthz` returns 200 (see nginx.conf). Cheap and unauthenticated.
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+  # Soft anti-affinity spreads replicas across nodes without blocking a small
+  # cluster. "hard" requires distinct nodes; "" / any other value disables it.
+  podAntiAffinity: soft
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  podAnnotations: {}
+  podLabels: {}
+  # Non-secret env for the nginx container, if ever needed. Usually empty.
+  extraEnv: []
+
+# ════════════════════════════════════════════════════════════════════════════
+# mcp — hosted MCP server (OPT-IN, disabled by default)
+# ════════════════════════════════════════════════════════════════════════════
+# Exposes the on-brand tool catalog + render path to AI agents over the Model
+# Context Protocol (Streamable-HTTP). Stateless. Listens on PORT (8790), serving
+# JSON-RPC at POST /mcp, the .well-known OAuth routes, and a public GET render
+# path. Enable this only if you want remote agents (e.g. claude.ai) to reach
+# your catalog. Like the web image, its tools/catalog are baked at build time.
+mcp:
+  enabled: false
+
+  replicaCount: 2
+
+  image:
+    #   docker build -f deploy/docker/mcp.Dockerfile -t <registry>/lolly-mcp:0.1.0 .
+    repository: ghcr.io/lolly-tools/lolly-mcp
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 80
+    # Container PORT the MCP http server listens on (default 8790).
+    targetPort: 8790
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: mcp.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+
+  # The MCP server has no unauthenticated GET health route, so probes use a TCP
+  # socket check — the port is open once the http server is listening.
+  livenessProbe:
+    tcpSocket:
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readinessProbe:
+    tcpSocket:
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+  # Point at your web deployment's origin to enable Tier-B (browser) render
+  # formats. Leave empty to run without a browser (svg/data + resvg-png still
+  # work). e.g. "https://lolly.example.com"
+  webBase: ""
+
+  podAntiAffinity: soft
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  podAnnotations: {}
+  podLabels: {}
+  # Extra non-secret env. For OAuth/provider secrets, mount your own secret via
+  # envFrom here or extend this chart — the MCP OAuth config is deployment-
+  # specific and intentionally not templated.
+  extraEnv: []
+  # e.g. [{ secretRef: { name: lolly-mcp-oauth } }]
+  extraEnvFrom: []
+
+# ════════════════════════════════════════════════════════════════════════════
+# ca — C2PA credential authority (OPT-IN, disabled by default)
+# ════════════════════════════════════════════════════════════════════════════
+# OIDC-verified short-lived X.509 leaf issuance for on-device C2PA signing.
+# Stateless (the only state is the root key/cert you supply). Listens on PORT
+# (8787), serving under /api/ca (GET /api/ca/health, /root.pem, OAuth routes,
+# POST /enroll). Enable only if your users need signed/credentialed assets.
+#
+# REQUIRES a root CA key + cert and a service secret. Generate the root once:
+#   node services/ca/scripts/gen-root.mjs
+# then supply the PEMs + secret via `ca.secrets` (chart-managed) OR
+# `ca.existingSecret` (recommended for production — see below).
+ca:
+  enabled: false
+
+  replicaCount: 2
+
+  image:
+    #   docker build -f deploy/docker/ca.Dockerfile -t <registry>/lolly-ca:0.1.0 .
+    repository: ghcr.io/lolly-tools/lolly-ca
+    tag: ""
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 80
+    # Container PORT the CA server listens on (default 8787).
+    targetPort: 8787
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: ca.example.com
+        paths:
+          - path: /api/ca
+            pathType: Prefix
+    tls: []
+
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
+  # GET /api/ca/health answers even before the root is configured.
+  livenessProbe:
+    httpGet:
+      path: /api/ca/health
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readinessProbe:
+    httpGet:
+      path: /api/ca/health
+      port: http
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+  # ── CA secrets ─────────────────────────────────────────────────────────────
+  # Mode A (chart-managed): fill these in and the chart creates a Secret.
+  # Mode B (recommended for prod): set `ca.existingSecret` to a secret you
+  # manage, and leave `ca.secrets` empty. Keys expected in the existing secret:
+  #   CA_SERVICE_SECRET, CA_ROOT_KEY_PEM, CA_ROOT_CERT_PEM  (required)
+  #   CA_ALLOWED_ORIGINS                                    (recommended)
+  #   GITHUB_CLIENT_SECRET, GOOGLE_CLIENT_SECRET, SUSE_CLIENT_SECRET (as used)
+  existingSecret: ""
+  secrets:
+    # openssl rand -hex 32 — HMAC key for OAuth state + enrollment tokens.
+    serviceSecret: ""
+    # PKCS#8 PEM of the root private key (from gen-root.mjs). Keep it safe.
+    rootKeyPem: ""
+    # PEM of the root certificate (public).
+    rootCertPem: ""
+    # Optional confidential OIDC client secrets, when you register providers.
+    githubClientSecret: ""
+    googleClientSecret: ""
+    suseClientSecret: ""
+
+  # Non-secret CA config (the public half of the OIDC provider registrations and
+  # issuance policy). Rendered into env directly. See services/ca/.env.example.
+  config:
+    # Comma list of origins allowed to receive enrollment tokens (your web host).
+    allowedOrigins: "https://lolly.example.com"
+    # Public OIDC client ids + issuers (set the ones you registered).
+    githubClientId: ""
+    googleClientId: ""
+    suseIssuer: ""
+    suseClientId: ""
+    # Issuance policy (optional). Days.
+    certDays: ""
+    certMaxDays: ""
+
+  podAntiAffinity: soft
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  podAnnotations: {}
+  podLabels: {}
+  extraEnv: []
+
+# ════════════════════════════════════════════════════════════════════════════
+# Shared pod runtime security (applied to every component)
+# ════════════════════════════════════════════════════════════════════════════
+# Secure defaults: run as a non-root user, drop all capabilities, no privilege
+# escalation, read-only root filesystem. The web image (nginx-unprivileged) runs
+# as uid 101; the node services run as uid 1000. fsGroup is unset so each image's
+# own default applies — override per install if your policy requires a fixed gid.
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+# ── NetworkPolicy ───────────────────────────────────────────────────────────
+# Off by default. When enabled, restricts ingress to each enabled component's
+# port; egress is left open (the MCP/CA services call out to IdPs and providers).
+networkPolicy:
+  enabled: false
+  # Allow ingress from pods in these namespaces (by label). Empty ⇒ allow from
+  # any pod in the same namespace (scope this to your ingress controller in prod).
+  ingressNamespaceSelector: {}
+  allowAllEgress: true


### PR DESCRIPTION
Adds `deploy/helm/` and `deploy/docker/` so an organization can self-host Lolly on Kubernetes with one `helm install`.

- **web** (on by default): the PWA served by nginx-unprivileged — the URL you give employees. Brand/profile is baked at build (`LOLLY_PROFILE`), so the image is self-contained (no runtime pack mount). SPA fallback + immutable asset caching + `/healthz` in `nginx.conf`.
- **mcp** / **ca** (opt-in, off by default): the MCP server and the CA service, each gated with their own Deployment/Service/Ingress. CA supports chart-managed or existing-secret modes with a fail-fast guardrail.
- Multi-stage Dockerfiles (`web`/`mcp`/`ca`), non-root + hardened defaults, gated ingress/NetworkPolicy.

`helm lint`/`template` clean (3.16.3): default renders 3 resources (web only); all components + CA + ingress + network-policy render 14.

Images not built here (no docker locally) — Dockerfiles hand-verified against the repo layout; build from repo root with content submodules checked out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)