### PR TITLE
SBOM self-repair on main, and branch protection so Dependabot auto-merge waits for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,10 @@
 #                     catalog/tools/index.json).
 #   audit           - every npm/Cargo lock is inventoried; npm audit and RustSec
 #                     block known vulnerabilities. Also checks SBOM freshness
-#                     (regenerate sbom.cdx.json, fail
-#                     on drift) + third-party notices (build:licenses exits 1 on a
+#                     (regenerate sbom.cdx.json, fail on drift - advisory only on
+#                     a dependabot[bot] PR, which cannot carry the regenerated
+#                     file; sbom-refresh.yml repairs main after the merge)
+#                     + third-party notices (build:licenses exits 1 on a
 #                     coverage gap; drift in the generated files fails the diff) +
 #                     cargo license-map coverage for every Cargo.lock crate.
 #   secrets         - Gitleaks scans all parent-repository history with redacted
@@ -512,10 +514,34 @@ jobs:
       # The committed CycloneDX SBOM (sbom.cdx.json) is generated from pnpm-lock.yaml
       # (scripts/build-sbom.ts, deterministic). Regenerate + fail on drift so it can't go
       # stale vs the installed graph - same discipline as the api-bundles drift gate.
-      - name: SBOM up to date (regenerate; fail on drift)
+      #
+      # One exception, and only one: Dependabot's own PRs. A bump changes a lockfile,
+      # so the SBOM moves, but Dependabot commits nothing except the lockfile and
+      # manifest - it cannot carry a regenerated artifact, and nobody can add one to
+      # its branch without taking the PR over by hand. Failing here would park every
+      # bump forever (or, worse, train us to merge red). So on a dependabot[bot] PR
+      # the drift is reported as a warning and the job carries on; main repairs itself
+      # straight after the merge via .github/workflows/sbom-refresh.yml, which
+      # regenerates and commits sbom.cdx.json on push.
+      #
+      # For every other actor this is still a hard failure: a human who touches a
+      # lockfile commits the regenerated SBOM alongside it, same as before.
+      - name: SBOM up to date (regenerate; fail on drift, warn for Dependabot)
+        env:
+          SBOM_DRIFT_ADVISORY: ${{ github.actor == 'dependabot[bot]' }}
         run: |
           pnpm run build:sbom
-          git diff --exit-code -- sbom.cdx.json
+          if git diff --quiet -- sbom.cdx.json; then
+            echo "sbom.cdx.json matches the dependency graph."
+            exit 0
+          fi
+          git --no-pager diff --stat -- sbom.cdx.json
+          if [ "$SBOM_DRIFT_ADVISORY" = 'true' ]; then
+            echo "::warning title=SBOM drift (advisory for Dependabot)::sbom.cdx.json is stale for this bump. sbom-refresh.yml regenerates and commits it on main once this merges."
+            exit 0
+          fi
+          echo "::error title=SBOM drift::sbom.cdx.json is stale. Run pnpm run build:sbom and commit the result."
+          exit 1
 
       # Third-party notices are generated the same way (scripts/build-licenses.ts).
       # The generator itself EXITS 1 when a distributed direct dependency is missing

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,29 +6,37 @@
 # What it does: when Dependabot opens a PR and CI goes green, this approves it and
 # enables GitHub auto-merge for the LOW-RISK update types only. Auto-merge then
 # completes the merge itself once every required check passes - so a red PR (e.g.
-# one that still needs its api-bundle/SBOM regenerated) is never merged here; it
-# simply waits, and the weekly routine picks it up.
+# one that still needs its api-bundle regenerated) is never merged here; it
+# simply waits, and the weekly routine picks it up. The one artifact a bump PR is
+# forgiven for is the SBOM, which no Dependabot branch can carry: ci.yml warns
+# instead of failing there, and sbom-refresh.yml regenerates it on main after the
+# merge. See those two files for the reasoning.
 #
 # ── PREREQUISITES (both required for this to do anything) ─────────────────────
 #   1. Repo setting "Allow auto-merge" = ON.        (already enabled 2026-08-14)
 #   2. Branch protection on `main` with >= 1 required status check.
 #      Without it GitHub REFUSES to enable auto-merge (the branch has no green-gate
-#      to wait on), so `gh pr merge --auto` errors and nothing merges. Suggested,
-#      with admins still able to push directly (keeps the direct-to-main workflow):
+#      to wait on), so `gh pr merge --auto` errors - and worse, with protection off
+#      the merge it did manage was IMMEDIATE, landing bumps that no job had passed.
+#      Applied 2026-09-12: every CI job is a required context, by the exact name
+#      GitHub reports it under (the test matrix appears once per shard, e.g.
+#      "test (unit:web)"), with `strict: false` so a bump branch is not forced to
+#      rebase onto every main commit, and `enforce_admins: false` so the
+#      maintainer keeps pushing to main directly. The applied payload is committed
+#      at security/branch-protection-main.json so it is reproducible rather than
+#      living only in one account's API history:
 #
+#        gh api repos/lolly-tools/lolly/branches/main/protection            # read
 #        gh api -X PUT repos/lolly-tools/lolly/branches/main/protection \
-#          --input - <<'JSON'
-#        { "required_status_checks": { "strict": true,
-#            "contexts": ["test","typecheck","validate catalog","build + bundle budget",
-#                         "api bundle drift","npm audit (high+critical)"] },
-#          "enforce_admins": false,
-#          "required_pull_request_reviews": null,
-#          "restrictions": null }
-#        JSON
+#          --input security/branch-protection-main.json                     # apply
 #
-#      NB: turning this on blocks ALL PRs (not just Dependabot's) until CI is green,
-#      and `main`'s CI is currently red on pre-existing generated-artifact drift
-#      (engine/README table + lolly-start catalog previews). Land that fix first.
+#      Its `contexts` list must track the job names in ci.yml. Add a job there and
+#      it is NOT required until it is added here and re-applied; rename one and the
+#      old name blocks every PR forever, because a context that never reports is
+#      simply pending.
+#
+#      NB: this gates ALL PRs, not just Dependabot's, so a shard that is red on
+#      main parks the whole queue until it is fixed.
 #
 # What it will NOT auto-merge: major bumps, and anything Dependabot is configured to
 # hold (e.g. onnxruntime-node majors, per .github/dependabot.yml). Those wait for a
@@ -69,9 +77,14 @@ jobs:
           steps.meta.outputs.update-type == 'version-update:semver-minor' ||
           steps.meta.outputs.package-ecosystem == 'docker' ||
           steps.meta.outputs.package-ecosystem == 'github_actions' )
+        # --delete-branch removes dependabot/* once the squash lands. Without it
+        # every merged bump left its branch on origin (15 had piled up by
+        # 2026-09-12), which makes the branch list useless for seeing what is
+        # actually in flight. Deletion happens at merge time, not now, so a PR
+        # left waiting on a red check keeps its branch.
         run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --squash "$PR_URL"
+          gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sbom-refresh.yml
+++ b/.github/workflows/sbom-refresh.yml
@@ -1,0 +1,133 @@
+# SBOM refresh - keeps the committed CycloneDX SBOM in step with main.
+#
+# WHY THIS EXISTS
+# sbom.cdx.json is a GENERATED artifact (scripts/build-sbom.ts) that describes the
+# whole dependency graph: the root pnpm lockfile, both Tauri shells' sibling
+# lockfiles and their Cargo.lock crate graphs, the vendored browser bundles and the
+# OFL fonts. CI's audit job regenerates it and fails on drift, exactly like the
+# api/ bundle gate, so a stale SBOM cannot ship.
+#
+# That gate has one blind spot, and Dependabot lives in it. A bump PR changes a
+# lockfile, so the SBOM moves - but Dependabot only ever commits the lockfile and
+# manifest, never a regenerated artifact, and the auto-merge workflow
+# (dependabot-auto-merge.yml) approves and merges patch/minor bumps as soon as the
+# required checks pass. The result was a queue of bumps each landing a lockfile
+# whose SBOM was never regenerated, and the next unrelated PR inheriting the
+# failure with no idea why. Rather than ask every contributor to carry someone
+# else's drift, the drift is repaired at the source: on main, right after the bump
+# lands, by the job below. The matching half of the deal is in ci.yml, where the
+# drift check is advisory (a warning) for dependabot[bot] and still fatal for
+# everyone else - a human who edits a lockfile still commits the SBOM with it.
+#
+# WHAT IT DOES
+# Regenerates sbom.cdx.json on main and, if it changed, commits just that file
+# back to main with GITHUB_TOKEN. A commit pushed with GITHUB_TOKEN does NOT
+# trigger workflows, which is what we want here: no CI run, and no chance of this
+# job retriggering itself. The trade is that the refresh commit is not itself
+# gated by CI - acceptable because the commit is machine-generated, one path wide,
+# and reproducible by anyone running `pnpm run build:sbom`.
+#
+# TRIGGERS
+# Path-filtered to the generator's actual inputs, so an ordinary docs or source
+# push to main does not pay for a pnpm install. If an input is ever missed, the
+# only symptom is the old behaviour (drift caught by the audit job), and
+# workflow_dispatch runs the refresh by hand.
+name: SBOM refresh
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - 'packages/*/package.json'
+      - 'engine/package.json'
+      - 'shells/*/package.json'
+      - 'shells/*/pnpm-lock.yaml'
+      - 'shells/*/src-tauri/Cargo.lock'
+      - 'services/*/package.json'
+      - 'security/npm-licenses.json'
+      - 'security/cargo-licenses.json'
+      - 'community/*/lib/*.min.js'
+      - 'scripts/build-sbom.ts'
+      - 'scripts/lib/pnpm-lock.ts'
+      - '.github/workflows/sbom-refresh.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Never cancel a run that may be mid-commit, and never run two at once: a second
+# push queues behind the first, then regenerates on top of its result.
+concurrency:
+  group: sbom-refresh
+  cancel-in-progress: false
+
+env:
+  # Same reason as ci.yml: onnxruntime-node's postinstall tries a CUDA download on
+  # Linux runners and dies on an unhandled rejection. Nothing here needs CUDA.
+  ONNXRUNTIME_NODE_INSTALL_CUDA: skip
+
+jobs:
+  refresh:
+    name: regenerate sbom.cdx.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          # brands/suse is `update = none` and private, so recursive is a no-op here.
+          # The generator is existence-guarded for exactly that case.
+          submodules: recursive
+
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+        with:
+          version: 11.26.0
+          run_install: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      # build-sbom reads lockfiles off disk rather than a resolved node_modules
+      # tree, but it imports the `yaml` package, so the workspace install is real.
+      - name: Install (workspaces)
+        run: pnpm install --frozen-lockfile
+
+      # Regenerate, and commit only if the file actually moved. A direct push to
+      # main can land between the checkout and our push, so a rejected push
+      # resets to the new main and regenerates there rather than force-pushing
+      # over it. Three attempts, then fail loudly - a persistent rejection is a
+      # real signal, not something to loop on.
+      - name: Regenerate the SBOM and commit it if it moved
+        run: |
+          set -uo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          for attempt in 1 2 3; do
+            pnpm run build:sbom || exit 1
+            if git diff --quiet -- sbom.cdx.json; then
+              echo "sbom.cdx.json already matches the dependency graph - nothing to commit."
+              exit 0
+            fi
+            git --no-pager diff --stat -- sbom.cdx.json
+            git add sbom.cdx.json
+            git commit --file=- <<'MSG' || exit 1
+          SBOM: regenerate after a dependency change landed on main
+
+          Generated by .github/workflows/sbom-refresh.yml (pnpm run build:sbom).
+          The committed CycloneDX SBOM is derived from the lockfiles, so a bump
+          that only touches a lockfile leaves it stale. This restores it, which
+          keeps the audit job's drift gate meaningful for the next PR.
+          MSG
+            if git push origin HEAD:main; then
+              echo "Committed a refreshed sbom.cdx.json to main (attempt ${attempt})."
+              exit 0
+            fi
+            echo "::notice::main moved under us; rebuilding on the new tip (attempt ${attempt})."
+            git fetch origin main
+            git reset --hard origin/main
+          done
+          echo "::error title=SBOM refresh could not push::main kept moving; run pnpm run build:sbom and commit sbom.cdx.json by hand."
+          exit 1

--- a/security/branch-protection-main.json
+++ b/security/branch-protection-main.json
@@ -1,0 +1,30 @@
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": [
+      "secret history scan",
+      "typecheck",
+      "validate catalog",
+      "smoke (render every tool)",
+      "build + bundle budget",
+      "api bundle drift",
+      "render-action self-test",
+      "npm audit (high+critical)",
+      "opengrep (custom rules + new findings)",
+      "test (unit:engine)",
+      "test (unit:web)",
+      "test (contracts)",
+      "test (security)",
+      "test (tools)",
+      "test (conformance)",
+      "test (fuzz:regression)",
+      "test (tauri)",
+      "test (browser)"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}


### PR DESCRIPTION
## Why

A Dependabot bump changes a lockfile, so the generated `sbom.cdx.json` moves - but a bump branch only ever carries the lockfile and manifest, and nothing can add a regenerated artifact to it without a human taking the PR over. The audit job's `git diff --exit-code -- sbom.cdx.json` therefore went red on bump PRs, and then on the next unrelated PR, which inherited drift it did not cause. Meanwhile `main` had **no branch protection**, so the auto-merge workflow's `gh pr merge --auto --squash` merged immediately, before any job reported.

## What changed

**`.github/workflows/sbom-refresh.yml` (new).** On a push to `main` that touches an SBOM input (root and both Tauri lockfiles, the `src-tauri/Cargo.lock` files, `security/npm-licenses.json` / `cargo-licenses.json`, the vendored `community/*/lib/*.min.js`, the generator and its lock reader), it runs `pnpm install --frozen-lockfile` + `pnpm run build:sbom` and, only if the file moved, commits it back to `main` with `GITHUB_TOKEN`. A `GITHUB_TOKEN` commit triggers no workflows, so there is no loop; the trade (the refresh commit is not itself CI-gated) is called out in the file, and is acceptable for a one-path machine-generated commit anyone can reproduce. A rejected push resets to the new `main` and regenerates there rather than forcing over a concurrent direct push - three attempts, then a loud failure. `workflow_dispatch` is there for a manual catch-up if a path filter ever misses an input. Every `uses:` is pinned to the same 40-char SHAs the other workflows use.

**`ci.yml`.** The drift check stays and stays fatal, except when `github.actor == 'dependabot[bot]'`, where it prints a `::warning` and exits 0. Reasoning is in the step comment: the bump PR physically cannot carry the file, and `main` repairs itself seconds after the merge. A human who touches a lockfile still commits the SBOM with it.

**`dependabot-auto-merge.yml`.** `--delete-branch` added to the auto-merge, so merged `dependabot/*` branches stop accumulating (15 sit on origin now). Deletion happens at merge time, so a PR parked on a red check keeps its branch. The stale PREREQUISITES comment is rewritten now that protection is real.

**`security/branch-protection-main.json` (new).** The exact payload applied, committed so it is reproducible rather than living only in one account's API history, with the read/apply commands and the "contexts must track ci.yml job names" caveat in the auto-merge comment.

## Branch protection, applied and verified

`gh api -X PUT repos/lolly-tools/lolly/branches/main/protection`, then read back:

```json
{
  "strict": false,
  "enforce_admins": false,
  "reviews": null,
  "restrictions": null,
  "allow_force_pushes": false,
  "allow_deletions": false,
  "required_conversation_resolution": false,
  "required_linear_history": false,
  "contexts": [
    "secret history scan", "typecheck", "validate catalog",
    "smoke (render every tool)", "build + bundle budget", "api bundle drift",
    "render-action self-test", "npm audit (high+critical)",
    "opengrep (custom rules + new findings)",
    "test (unit:engine)", "test (unit:web)", "test (contracts)",
    "test (security)", "test (tools)", "test (conformance)",
    "test (fuzz:regression)", "test (tauri)", "test (browser)"
  ]
}
```

All 18 names were taken from what GitHub actually reports on `main`'s check runs, not guessed. `strict: false` so a bump branch is not forced to rebase onto every `main` commit; `enforce_admins: false` so the maintainer keeps pushing to `main` directly.

**Consequence worth knowing before merging anything:** Dependabot PRs now merge only when **every** one of those 18 jobs is green, which gates all PRs, not just Dependabot's. So the browser-shard fix (lane `ci/browser-shard`) has to land first - while `test (browser)` is red on `main`, the whole cargo/npm bump queue stays parked. Admins can still bypass (`enforce_admins: false`), and a renamed CI job must be renamed in `security/branch-protection-main.json` and re-applied, or its old context stays pending forever.

## Checks run

- `node --test tests/workflow-pins.test.ts tests/scan-secrets-runner.test.ts` - 6/6 pass (pins test sees the new workflow)
- `node --test tests/catalog-release.test.ts` - 8/8 pass
- `python3 -c "import yaml"` parse of all three workflows plus the new JSON - OK
- `node scripts/check-code-comment-vernacular.ts`, `node scripts/check-docs-vernacular.ts` - clean
- `node scripts/check-changed-lint.ts --all` - 2994 files, no new diagnostics
- `node scripts/release-checklist.ts --check` - clean with the new `security/` file
- `pnpm run build:sbom` in a fresh worktree - reproduces the committed SBOM byte for byte (no drift), which is the premise the refresh job rests on
- Both shell scripts exercised for real, not just eyeballed: the audit step's three outcomes (clean / drift as a human / drift as `dependabot[bot]`) against a scratch repo, and the refresh job's commit, no-op and push-rejected-then-rebuild paths against a local bare remote - the retry preserved the concurrent commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFUV4W9E3Vvtxt78ZBSM2u
