### PR TITLE
CI browser shard: install the Chromium the gates look for, and measure the tilted PDF instead of weighing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,12 @@ jobs:
       # scoped Chromium into the same `.browsers` the shells' resolver
       # (packages/node-shell/src/browsers.ts) and `playwright`'s executablePath()
       # both read via PLAYWRIGHT_BROWSERS_PATH, so the shard tests what its name says.
+      # It only works while `playwright-core` (what the installer drives) and `playwright`
+      # (what the gates call executablePath() on) are the same release - they want
+      # different chromium-<revision> directories otherwise, and the shard skips its whole
+      # tier on a runner that has a browser. pnpm-workspace.yaml holds them together and
+      # tests/browser-tier-install.test.ts asserts it; the cache key below is that same
+      # resolved version, so a bump re-downloads instead of serving the wrong revision.
       - name: Cache Chromium (browser shard)
         if: matrix.shard == 'browser'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -55,3 +55,12 @@ commits = [
   "f9638ec6a3ba1c0d8170307db871544cb36c6a65",
   "6d7aa4a393321fb35c78312f2e0dd17bb7360e87",
 ]
+
+[[allowlists]]
+description = "The prepare/redact text test carries an inert token-shaped fixture so the redactor has something to find"
+condition = "AND"
+targetRules = ["aws-access-token"]
+paths = ['''^tests/prepare-text\.test\.ts$''']
+commits = [
+  "02a16b8ba7aed1b4c8c112d1b95d54d7d675f4b0",
+]

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -3019,7 +3019,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 ```
 
-### playwright-core 1.62.1
+### playwright-core 1.63.0
 
 - SPDX-License-Identifier: `Apache-2.0`
 - Copyright: copyright notice that is included in or attached to the work; copyright license to reproduce, prepare Derivative Works of,; (c) You must retain, in the Source form of any Derivative Works

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   },
   "dependencies": {
     "@resvg/resvg-js": "^2.6.2",
-    "playwright-core": "^1.62.1"
+    "playwright-core": "^1.63.0"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.124.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   nanoid: ^3.3.17
   '@huggingface/transformers>sharp': ^0.35.4
   '@huggingface/transformers>onnxruntime-node': ^1.29.0
+  playwright-core: ^1.63.0
 
 importers:
 
@@ -20,8 +21,8 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
       playwright-core:
-        specifier: ^1.62.1
-        version: 1.62.1
+        specifier: ^1.63.0
+        version: 1.63.0
     devDependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.124.0
@@ -156,8 +157,8 @@ importers:
         specifier: ^1.17.1
         version: 1.17.1
       playwright-core:
-        specifier: ^1.49.0
-        version: 1.62.1
+        specifier: ^1.63.0
+        version: 1.63.0
     devDependencies:
       typescript:
         specifier: ^5.5.0
@@ -204,8 +205,8 @@ importers:
         version: 0.22.0(@types/node@26.5.0)(@types/react@18.3.31)(supports-color@8.1.1)(typescript@5.9.3)
     optionalDependencies:
       playwright-core:
-        specifier: ^1.49.0
-        version: 1.62.1
+        specifier: ^1.63.0
+        version: 1.63.0
 
   shells/cli:
     dependencies:
@@ -231,8 +232,8 @@ importers:
         specifier: ^1.17.1
         version: 1.17.1
       playwright-core:
-        specifier: ^1.49.0
-        version: 1.62.1
+        specifier: ^1.63.0
+        version: 1.63.0
       zxing-wasm:
         specifier: 3.1.3
         version: 3.1.3(@types/emscripten@1.41.5)
@@ -267,8 +268,8 @@ importers:
         specifier: ^1.17.1
         version: 1.17.1
       playwright-core:
-        specifier: ^1.49.0
-        version: 1.62.1
+        specifier: ^1.63.0
+        version: 1.63.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -3055,11 +3056,6 @@ packages:
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
-
-  playwright-core@1.62.1:
-    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
-    engines: {node: '>=20'}
-    hasBin: true
 
   playwright-core@1.63.0:
     resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
@@ -6178,8 +6174,6 @@ snapshots:
   pkce-challenge@5.0.1: {}
 
   platform@1.3.6: {}
-
-  playwright-core@1.62.1: {}
 
   playwright-core@1.63.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,3 +29,14 @@ overrides:
   'nanoid': '^3.3.17'
   '@huggingface/transformers>sharp': '$sharp'
   '@huggingface/transformers>onnxruntime-node': '$onnxruntime-node'
+  # One Chromium revision for the whole repo. `playwright` pins its own
+  # `playwright-core` to an exact version, and each release expects a different
+  # `chromium-<revision>` directory. The browser is downloaded by the CLI installer
+  # through playwright-core (shells/cli/src/install-browser.ts), while the browser-tier
+  # tests and the capture scripts launch it through the full `playwright`. Let those two
+  # drift a minor apart and the installer writes chromium-1234 while the tests look for
+  # chromium-1243, so every one of them skips with "no Chromium" on a machine that has
+  # one. Pinning core to whatever `playwright` asks for keeps the download and the
+  # lookup on the same revision, including for the workspace packages that ask for a
+  # much older floor (shells/cli, shells/tui, packages/node-shell, services/mcp).
+  'playwright-core': '$playwright'

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:62d885db-4cc8-4acd-8cab-48a5e8bfb729",
+  "serialNumber": "urn:uuid:ff0417a8-4d27-4cad-8122-2cdab16d43d9",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-09-11T23:26:30.483Z",
+    "timestamp": "2026-09-11T23:58:03.694Z",
     "tools": [
       {
         "vendor": "lolly",
@@ -32297,10 +32297,10 @@
     },
     {
       "type": "library",
-      "bom-ref": "pkg:npm/playwright-core@1.62.1",
+      "bom-ref": "pkg:npm/playwright-core@1.63.0",
       "name": "playwright-core",
-      "version": "1.62.1",
-      "purl": "pkg:npm/playwright-core@1.62.1",
+      "version": "1.63.0",
+      "purl": "pkg:npm/playwright-core@1.63.0",
       "scope": "required",
       "licenses": [
         {
@@ -32312,34 +32312,7 @@
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "c0f612c0404963d187ada2125eacaab71d276b42e93b75c45fb8cd0e19ed6dec7bb73512ee42e766c3a516bb85241e078bfae10cc8d71aa1dec0367af2761957"
-        }
-      ]
-    },
-    {
-      "type": "library",
-      "bom-ref": "pkg:npm/playwright-core@1.63.0",
-      "name": "playwright-core",
-      "version": "1.63.0",
-      "purl": "pkg:npm/playwright-core@1.63.0",
-      "scope": "excluded",
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache-2.0"
-          }
-        }
-      ],
-      "hashes": [
-        {
-          "alg": "SHA-512",
           "content": "ad80ac045fcce478d4721e766dbb5538d1058efe97bbcb26f21ef674d951e5bcc81357ef0bf6f182ca7392349f53e3307843263ccf0a25e6c6ea79f2c68e660a"
-        }
-      ],
-      "properties": [
-        {
-          "name": "cdx:npm:package:development",
-          "value": "true"
         }
       ]
     },

--- a/shells/web/src/README.md
+++ b/shells/web/src/README.md
@@ -11,7 +11,7 @@ Roughly 529,000 lines of TypeScript, tests included, and 46,000 lines of CSS.
 |---|---|---|---|
 | `views/` | 257 files, 144,643 lines | 136 files, 52,360 lines | 3 files, 193 lines |
 | `lib/` | 489 files, 112,101 lines | 296 files, 58,721 lines | 10 files, 1,256 lines |
-| `bridge/` | 129 files, 45,399 lines | 85 files, 20,074 lines | none |
+| `bridge/` | 129 files, 45,399 lines | 85 files, 20,082 lines | none |
 | `components/` | 64 files, 20,928 lines | 28 files, 9,514 lines | 8 files, 611 lines |
 | `collab/` | 20 files, 13,525 lines | 22 files, 14,131 lines | none |
 | `pro/` | 22 files, 8,386 lines | 11 files, 1,738 lines | 3 files, 1,226 lines |

--- a/shells/web/src/bridge/export-format-golden.test.ts
+++ b/shells/web/src/bridge/export-format-golden.test.ts
@@ -32,9 +32,17 @@
  * toPath goldens. The same applies ACROSS OSes at the same Chromium version:
  * text layout goes through the platform font backend (CoreText on macOS,
  * FreeType on Linux), so glyph advances in the text-bearing fixtures can
- * differ per-OS. These goldens were generated on macOS; if a Linux dev
- * machine ever runs them (CI has no Chromium, so not there) a text-fixture
- * mismatch with plausible-looking coordinates is that, not a regression.
+ * differ per-OS. These goldens were generated on macOS, so a mismatch on
+ * another OS with plausible-looking coordinates is that, not a regression.
+ *
+ * Which now matters in CI. This header used to add "CI has no Chromium, so not
+ * there", and that was true only because the browser shard's install wrote a
+ * different chromium revision than the gate above looks for - it skipped its
+ * whole tier. That is fixed, so the Linux runner really does render these four
+ * formats. If the two text fixtures (html-card, svg-native) mismatch there while
+ * linear-gradient passes, the font backend is the reason: generate a Linux set
+ * with UPDATE_GOLDENS=1 on a runner and review the diff, rather than relaxing
+ * the byte comparison, which is the only thing this file is for.
  *
  * Run directly:            node --test shells/web/src/bridge/export-format-golden.test.ts
  * Regenerate the goldens:  UPDATE_GOLDENS=1 node --test shells/web/src/bridge/export-format-golden.test.ts

--- a/tests/browser-tier-install.test.ts
+++ b/tests/browser-tier-install.test.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MPL-2.0
+/**
+ * The browser tier installs the revision the browser tier looks for.
+ *
+ * Two packages are in play, on purpose. `lolly install-browser`
+ * (shells/cli/src/install-browser.ts) downloads Chromium through the
+ * `playwright-core` CLI, because that is the only playwright package the shipped
+ * shells depend on - a plain `pnpm install` must never pull a browser. The
+ * browser-tier TESTS and the capture scripts launch it through the full
+ * `playwright`, which is a dev-only dependency.
+ *
+ * Each playwright release wants its OWN `chromium-<revision>` directory, and
+ * `playwright@X` pins `playwright-core@X` exactly. So the moment the two drift a
+ * minor apart, the installer writes one revision and every gate looks for another:
+ * `chromium.executablePath()` points at a directory that does not exist, the
+ * `existsSync` check in each browser-gated suite fails, and the whole tier reports
+ * "no Chromium (pnpm exec playwright install chromium)" on a machine that has one.
+ *
+ * That is not hypothetical. Between 2026-09-08 and 2026-09-11 the CI browser shard
+ * installed Chromium, cached it, pointed PLAYWRIGHT_BROWSERS_PATH at it, and still
+ * skipped 149 tests: playwright-core sat at 1.62.1 (chromium-1234) while playwright
+ * was at 1.63.0 (chromium-1243). The versions are held together by the
+ * `playwright-core: '$playwright'` override in pnpm-workspace.yaml; this is the
+ * assertion that says so out loud, so a lockfile change cannot quietly undo it and
+ * leave a green-looking shard that tested nothing.
+ */
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const version = (name: string): string => (require(`${name}/package.json`) as { version: string }).version;
+
+test('playwright and playwright-core resolve to the same release', () => {
+  const full = version('playwright');
+  const core = version('playwright-core');
+  assert.equal(core, full,
+    `playwright ${full} expects playwright-core ${full}, but ${core} is installed. `
+    + 'The installer drives playwright-core and the gates drive playwright, so a split '
+    + 'here makes every browser-tier test skip. Check the playwright-core override in '
+    + 'pnpm-workspace.yaml.');
+
+  // The pin playwright itself declares, in case the tree ever hoists a second copy.
+  const declared = (require('playwright/package.json') as { dependencies?: Record<string, string> })
+    .dependencies?.['playwright-core'];
+  assert.equal(declared, full, `playwright ${full} declares playwright-core ${declared}`);
+});
+
+test('the installer and the gates name the same chromium revision directory', () => {
+  const before = process.env.PLAYWRIGHT_BROWSERS_PATH;
+  process.env.PLAYWRIGHT_BROWSERS_PATH = '/nonexistent-browsers-root';
+  try {
+    // executablePath() is pure path arithmetic - it reports where the browser WOULD
+    // live, with no check that it is there, which is exactly the number compared here.
+    const revision = (name: string): string => {
+      const { chromium } = require(name) as { chromium: { executablePath: () => string } };
+      return /(chromium[^/\\]*-\d+)/.exec(chromium.executablePath())?.[1] ?? '';
+    };
+    const gate = revision('playwright');
+    const installer = revision('playwright-core');
+    assert.ok(gate, 'playwright reports no chromium revision directory');
+    assert.equal(installer, gate,
+      `the installer writes ${installer} and the browser gates look in ${gate}`);
+  } finally {
+    if (before === undefined) delete process.env.PLAYWRIGHT_BROWSERS_PATH;
+    else process.env.PLAYWRIGHT_BROWSERS_PATH = before;
+  }
+});

--- a/tests/expected-skips.json
+++ b/tests/expected-skips.json
@@ -3,1046 +3,129 @@
   "environment": "ci-ubuntu",
   "skips": [
     {
-      "file": "shells/web/src/bridge/export-atomic-inline.test.ts",
-      "fullName": "a plain display:inline is still left to the text pass, and paints once",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-atomic-inline.test.ts",
-      "fullName": "an inline <img> is emitted - replaced content defaults to display:inline",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-atomic-inline.test.ts",
-      "fullName": "an inline-block border is painted",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-atomic-inline.test.ts",
-      "fullName": "an inline-block keeps its background",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-atomic-inline.test.ts",
-      "fullName": "an inline-flex keeps its background",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-atomic-inline.test.ts",
-      "fullName": "nested inline-blocks each paint their own box, once",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-backdrop-blur.test.ts",
-      "fullName": "a backdrop-filter that is more than a plain blur is not faked",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-backdrop-blur.test.ts",
-      "fullName": "a blurred backdrop is reconstructed: content behind is cloned, clipped and blurred",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-backdrop-blur.test.ts",
-      "fullName": "a chained backdrop-filter reaches the raster hatch too",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-backdrop-blur.test.ts",
-      "fullName": "a reconstructed panel does NOT rasterise - the caps stay honest in both directions",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-backdrop-blur.test.ts",
-      "fullName": "a rotated frosted panel is left alone rather than double-transformed",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-backdrop-blur.test.ts",
-      "fullName": "a rotated frosted panel reaches the raster hatch instead of silently dropping the frost",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-backdrop-blur.test.ts",
-      "fullName": "the filter region is scoped to the element box, not the duplicated backdrop",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-bg-layers.test.ts",
-      "fullName": "a single-layer gradient still emits exactly one gradient with its own stops",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-bg-layers.test.ts",
-      "fullName": "each layer takes its OWN background-size, not the first entry in the list",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-bg-layers.test.ts",
-      "fullName": "two stacked linear-gradients emit TWO gradients, not one merged stop list",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-emf-eps-shadow.test.ts",
-      "fullName": "a hard-edged shadow is ONE shape, not a ramp",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-emf-eps-shadow.test.ts",
-      "fullName": "a soft shadow reaches EMF/EPS as a ramp of distinct shapes",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-emf-eps-shadow.test.ts",
-      "fullName": "an inset shadow also survives to these formats",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-emf-eps-shadow.test.ts",
-      "fullName": "no shadow means no extra shapes",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-emf-eps-shadow.test.ts",
-      "fullName": "the rings paint BEFORE the element background, so it covers them",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-form-controls.test.ts",
-      "fullName": "a CSS-styled control is not given a second, UA-shaped widget",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-form-controls.test.ts",
-      "fullName": "a native range paints a track and a thumb positioned by its value",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-form-controls.test.ts",
-      "fullName": "a password field paints bullets, not the password",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-form-controls.test.ts",
-      "fullName": "a placeholder stands in for an empty value, in the placeholder colour",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-form-controls.test.ts",
-      "fullName": "a select paints its chosen option, not its first",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-form-controls.test.ts",
-      "fullName": "a textarea keeps its lines",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-form-controls.test.ts",
-      "fullName": "an input's value reaches the output - the blank-field defect",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-form-controls.test.ts",
-      "fullName": "control text is clipped to the field, so an over-long value cannot escape it",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-form-controls.test.ts",
-      "fullName": "the mirror element used for layout does not survive the export",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "Chromium parses --force-color-profile (counterfactual: display-p3 flips the gamut query)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: html-card renders byte-exact dxf",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: html-card renders byte-exact emf",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: html-card renders byte-exact eps",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: html-card renders byte-exact svg",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: linear-gradient renders byte-exact dxf",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: linear-gradient renders byte-exact emf",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: linear-gradient renders byte-exact eps",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: linear-gradient renders byte-exact svg",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: svg-native renders byte-exact dxf",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: svg-native renders byte-exact emf",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: svg-native renders byte-exact eps",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "golden: svg-native renders byte-exact svg",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-format-golden.test.ts",
-      "fullName": "negative control: a perturbed fixture produces different bytes in every format",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-layer-ids.test.ts",
-      "fullName": "an element with no id contributes none - ids only where the canvas minted one",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-layer-ids.test.ts",
-      "fullName": "OFF (the default): the emitted bytes are identical with and without the option present",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-layer-ids.test.ts",
-      "fullName": "ON: a rotated box still gets exactly one stamp (the walker re-enters itself there)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-layer-ids.test.ts",
-      "fullName": "ON: each stamped element's own <g> carries its id, and nothing else changes",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-layer-ids.test.ts",
-      "fullName": "the round trip closes: a stamped walker SVG lifts along the CANVAS's boundaries",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "a <canvas> exports its pixels instead of an empty box",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "a background image at its intrinsic size is not stretched",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "a blank canvas still emits, and a tainted one does not throw",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "a blur filter gets a filter region big enough to hold the spread",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "a CSS filter is emitted as an SVG filter rather than dropped",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "a drop-shadow-only filter adds no SVG filter, since it is drawn as geometry",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "a fixed-size background image keeps its size and position",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "a host's unslotted light children are NOT painted",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "a replaced element inside a plain-inline wrapper is not dropped",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "a tiling background becomes a <pattern>, not a screenshot",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "an inline svg using currentColor keeps the page's inherited color",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "cover still fills the box - the case the old behaviour got right",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "shadow-root content is walked - it used to be invisible entirely",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-m3.test.ts",
-      "fullName": "slotted light content paints exactly once",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-nested-svg.test.ts",
-      "fullName": "a class-styled status ring survives: computed fill/stroke baked inline, vars and classes collapsed",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-nested-svg.test.ts",
-      "fullName": "a stroke=\"var(--series)\" ATTRIBUTE paints standalone - the computed literal is baked over it",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-nested-svg.test.ts",
-      "fullName": "nested-svg <text> carries its inherited font and fill - no more viewer-default serif",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-nested-svg.test.ts",
-      "fullName": "url(#…) paints survive verbatim - a gradient fill is referenced, never clobbered by a literal",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "a canvas with NO vector twin serialises byte-identically before and after the feature exists",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "a positioned child paints AFTER its parent's inline text (E.2 step 5 then 8)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "a twin producer that re-enters the walker gets NO twins inside it (depth guard)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "a unit hoisted out of an overflow-clip group re-applies the clip",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "a z-index:-1 child paints after its context's own background and before in-flow content",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "a z-indexed child hoists OUT of a non-stacking-context ancestor",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "every twin-producer failure mode falls back to the unmodified raster path",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "flag OFF: emitted order is exactly document order, even on a heavily z-indexed tree",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "hoisting stops at isolation:isolate",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "hoisting stops at opacity<1 - a z-index:99 child stays inside the opacity group",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "KNOWN LIMITATION: floats are painted in tree order, not section E.2 layer 4",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "position:relative;z-index:2 declared FIRST still paints above a later static sibling",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-paint-order.test.ts",
-      "fullName": "z-index sorts positioned siblings: declared 40,30,20 must PAINT 20,30,40",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-pdf-filter.test.ts",
-      "fullName": "a mixed blur + drop-shadow chain is measured for spill, not silently written off",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-pdf-filter.test.ts",
-      "fullName": "blur, shadow:content and shadow:depth each reach the PDF as an embedded image",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-pdf-filter.test.ts",
-      "fullName": "the same filters stay VECTOR in SVG - the PDF cap must not leak across walkers",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: CONTROL: no-shadow box",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: CONTROL: plain text",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: drop-shadow",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: elliptical radial gradient",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: hard outer shadow",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: inset shadow",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: layer blur",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: layer blur + drop-shadow",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: layer blur over a box-shadow",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: outer shadow under a translucent background",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: rotated box",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: rotated box, other direction",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: shadow with spread",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: skewed box (raw matrix)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: soft outer shadow",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: text-shadow, blurred",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-pdf-shadow-fidelity.test.ts",
       "fullName": "pdf shadow fidelity: text-shadow, hard offset",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-pseudo-position.test.ts",
-      "fullName": "a backdrop-filtered STATIC ancestor is the containing block, not the positioned one",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-pseudo-position.test.ts",
-      "fullName": "a pseudo's own translate is applied (top:50% + translateY(-50%) centres it)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-pseudo-position.test.ts",
-      "fullName": "a rotated pseudo emits a transform about its own origin",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: CONTROL: plain text, no shadow",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: drop-shadow",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: drop-shadow, blur larger than the element",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: drop-shadow, opaque colour",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: hard outer shadow (no blur, pure geometry)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: inset shadow",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: outer shadow under a TRANSLUCENT background",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: shadow with spread",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: soft outer shadow",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: text-shadow, blurred",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: text-shadow, hard offset",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-shadow-fidelity.test.ts",
-      "fullName": "shadow fidelity: text-shadow, large blur",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "no PDF rasteriser binary (needs swiftc or pdftoppm)",
+      "capability": "external-tool",
       "owner": "shells/web"
     },
     {
       "file": "shells/web/src/bridge/export-stroke-paint.test.ts",
       "fullName": "strokeOf: a class-declared stroke on the real catalog artwork resolves (PDF outlines)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-stroke-paint.test.ts",
-      "fullName": "strokeOf/strokeWidthOf: attribute > inline style > CSS class, and SVG defaults",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a background-image whose data-URI contains quotes is emitted, not dropped",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a fully TRANSPARENT band paints nothing at all",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a HARD-STOPPED conic emits one EXACT sector per band, not a sampled fan",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a percentage-only gradient is untouched by the px conversion",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a plain path and an unquoted url() still parse (no regression from the quote fix)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a print-dpi export keeps a higher-resolution raster than a screen export",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a run the font cannot cover (notdef) keeps its <text> instead of emitting tofu",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a run whose font resolves is emitted as <path> glyph outlines, not <text>",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a run with no resolvable font file falls back to <text>",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a TILED conic background becomes one <pattern>, not an element-sized sweep",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a TILED gradient layer becomes a <pattern>, not an element-sized sweep",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "a variable-font weight reaches the shaper (Outfit is wght 100..900)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "an <img> with a PATH src is inlined as a data: URI, not left as a fetchable href",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "an absolute px stop position becomes a fraction of the gradient line, not \"Npx\"",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "an oversized bitmap is downscaled to what its display box can show",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "an UNTILED conic with a real RAMP is still emitted as a wedge fan",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "an UNTILED gradient still fills the element directly, with no pattern",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "CHARACTERIZATION: a mixed run (covered Latin + one uncovered CJK char) falls back to <text> as a WHOLE",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "convertPaths:false keeps every run as selectable <text>",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "emission is deterministic - the same markup exports byte-identical SVG",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "font-feature-settings reaches the shaper (frac changes the emitted geometry)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "interleaved HTML renders retain their shaping and logging capabilities across blocks",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "letter-spacing reaches the shaper and changes the emitted geometry",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "text inside a SCALED element exports at the size the browser paints it",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "text shadow filter IDs are deterministic and owned by each render",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-text-emission.test.ts",
-      "fullName": "text-transform is applied BEFORE shaping, not left to the renderer",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-transform-animation.test.ts",
-      "fullName": "a RUNNING transform transition walks once, not once per attempt",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-transform-animation.test.ts",
-      "fullName": "a statically rotated element: one wrapper group, shallow tree (the baseline)",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-transform-animation.test.ts",
-      "fullName": "a transform an author `!important` rule owns falls to the AABB path, bounded",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-transform-animation.test.ts",
-      "fullName": "an element that only DECLARES a transform transition explodes too - and must not",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-transform-animation.test.ts",
-      "fullName": "an INFINITE transform animation terminates, and the page keeps spinning",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
-      "owner": "shells/web"
-    },
-    {
-      "file": "shells/web/src/bridge/export-transform-animation.test.ts",
-      "fullName": "no transform animation anywhere: the same DOM exports the same bytes twice",
-      "reason": "no Chromium (pnpm exec playwright install chromium)",
-      "capability": "browser",
+      "reason": "SUSE brand pack not mounted (see profiles.json)",
+      "capability": "brand:suse",
       "owner": "shells/web"
     },
     {

--- a/tests/tilt-still-vector.browser.test.ts
+++ b/tests/tilt-still-vector.browser.test.ts
@@ -73,6 +73,46 @@ function analyticTaper(kf: string, box: { x: number; y: number; w: number; h: nu
   return Math.abs(bot) / Math.abs(top);
 }
 
+/**
+ * The image XObjects a finished PDF carries, split into the pictures and their soft
+ * masks (a mask is the DeviceGray sibling an embed with alpha gets).
+ *
+ * WHY THIS IS MEASURED AND NOT WEIGHED. This case used to assert
+ * `tiltedBytes > untiltedBytes * 1.5`, a weight proxy calibrated against the jsPDF
+ * writer this shell carried until 2026-09-11, under which the ratio had room to spare.
+ * It has none under the pdf-lib writer (export-pdf-doc.ts), which Flate-compresses each
+ * embed - the two cards here come to 989 B and 1315 B - against an untilted baseline of
+ * 6.5 KB that is 5.4 KB content-independent boilerplate (a 2336 B sRGB profile and a
+ * 3058 B XMP packet, both written by the PDF/X pass for every export). What is left of
+ * the ratio only asks how well a solid-colour card's antialiased edges happen to deflate
+ * on the host, which is a property of the rasteriser and not of the export path: 1.78
+ * measured on macOS, 1.48 on the Linux CI runner, so the shard failed there and only
+ * there.
+ *
+ * Counting the XObjects asks the file the question the ratio was standing in for, and
+ * asks it exactly: an embed is present, or it is not.
+ *
+ * A regex over the raw bytes is sound here. pdf-lib saves with object streams, but an
+ * object carrying a stream can never live inside one, so every image dictionary is
+ * plain text in the file.
+ */
+function countImageXObjects(pdf: Buffer): { colour: number; gray: number; total: number } {
+  const text = pdf.toString('latin1');
+  let colour = 0;
+  let gray = 0;
+  const key = /\/Subtype\s*\/Image/g;
+  for (let m = key.exec(text); m; m = key.exec(text)) {
+    // The dictionary this key belongs to, read between its object header and the
+    // stream data it introduces, so a nested entry cannot truncate the window.
+    const from = text.lastIndexOf('obj', m.index);
+    const to = text.indexOf('stream', m.index);
+    const dict = text.slice(from < 0 ? 0 : from, to < 0 ? m.index + 512 : to);
+    if (/\/ColorSpace\s*\/DeviceGray/.test(dict)) gray++;
+    else colour++;
+  }
+  return { colour, gray, total: colour + gray };
+}
+
 const measured: string[] = [];
 
 describe('plans/104 section 12 Q2 - a tilted still keeps the untilted layers vector', { skip: gate ?? false, concurrency: 1 }, () => {
@@ -239,17 +279,34 @@ describe('plans/104 section 12 Q2 - a tilted still keeps the untilted layers vec
       } }).SEQ;
       const a = await S.vectorStillAt(tilt, t, 'pdf');
       const b = await S.vectorStillAt(flat, t, 'pdf');
-      return { tiltSize: a.size, flatSize: b.size, head: (await S.blobBytes(a.key)).slice(0, 24) };
+      return {
+        tiltSize: a.size, flatSize: b.size,
+        tilt: await S.blobBytes(a.key), flat: await S.blobBytes(b.key),
+      };
     }, { tilt: scene(TILT_KF), flat: scene(FLAT_KF), t: AT });
 
-    assert.match(atob(r.head).slice(0, 5), /^%PDF-/, 'it is a PDF');
-    // Two embedded PNGs against two vector rects: the file has to be substantially
-    // larger. This is a coarse instrument on purpose - the fine one is the SVG taper
-    // above, and the point here is only that PDF took the same branch rather than
-    // silently keeping the AABB path.
-    assert.ok(r.tiltSize > r.flatSize * 1.5,
-      `a tilted PDF (${r.tiltSize}B) should carry rasters the untilted one (${r.flatSize}B) does not`);
-    measured.push(`pdf: tilted ${r.tiltSize} B vs untilted ${r.flatSize} B`);
+    const tiltBytes = Buffer.from(r.tilt, 'base64');
+    const flatBytes = Buffer.from(r.flat, 'base64');
+    assert.equal(tiltBytes.subarray(0, 5).toString('latin1'), '%PDF-', 'it is a PDF');
+    const tilted = countImageXObjects(tiltBytes);
+    const flat = countImageXObjects(flatBytes);
+
+    // The branch, read off the file rather than guessed from its weight: one colour
+    // image XObject per tilted box, and NONE at all when nothing is tilted. An
+    // implementation that kept the AABB vector path emits rects and no image at all,
+    // which is the wrong picture this test exists to refuse - the same discriminator
+    // the SVG cases above use, and the fine instrument for the form of the picture is
+    // still the taper measured there.
+    assert.equal(tilted.colour, 2,
+      `one embed per tilted box, got ${tilted.colour} colour + ${tilted.gray} mask images`);
+    assert.equal(flat.total, 0,
+      `an untilted PDF must carry no raster at all, got ${flat.total} image XObjects`);
+    // Those embeds are bytes the untilted file does not carry. A strict inequality,
+    // not a ratio: see the note on countImageXObjects for why a ratio cannot work here.
+    assert.ok(r.tiltSize > r.flatSize,
+      `a tilted PDF (${r.tiltSize}B) carries rasters the untilted one (${r.flatSize}B) does not`);
+    measured.push(`pdf: tilted ${r.tiltSize} B (${tilted.colour} embeds + ${tilted.gray} masks) `
+      + `vs untilted ${r.flatSize} B (${flat.total} embeds)`);
   });
 
   // ── 5: S2's own discriminator, kept as a test (S2 section 9.1) ────────────────────


### PR DESCRIPTION
Two faults in the CI browser shard, both of which made it report something other than what it tested.

## 149 skips on a runner that had a browser

The shard installed Chromium, cached it and set `PLAYWRIGHT_BROWSERS_PATH`, and still reported 149 skips reading `no Chromium (pnpm exec playwright install chromium)`.

Two playwright packages are in play on purpose. `lolly install-browser` downloads through `playwright-core`, because that is the only playwright the shipped shells depend on and a plain `pnpm install` must never pull a browser; the browser-tier tests and the capture scripts launch through the full `playwright`. The root manifest had them a minor apart (`playwright-core ^1.62.1` against `playwright ^1.63.0`), and each release wants its own `chromium-<revision>` directory:

```
installer (playwright-core 1.62.1) -> .browsers/chromium-1234/...
gates      (playwright      1.63.0) -> .browsers/chromium-1243/...   existsSync false -> skip
```

`playwright@X` pins `playwright-core@X` exactly, so the fix is to stop letting them drift: a `playwright-core: '$playwright'` override in `pnpm-workspace.yaml`, which also pulls the four workspace packages asking for a `^1.49.0` floor onto the same release. `tests/browser-tier-install.test.ts` asserts the invariant two ways - resolved versions, and the revision directory each package names - so a lockfile change cannot quietly undo it and leave a green-looking shard that ran nothing.

Measured locally with `PLAYWRIGHT_BROWSERS_PATH` on a fresh install: **149 "no Chromium" skips to 0**, 1175 passing, 0 failing, 56 skips left (all environment-driven: no served web shell, no `dist`, no brand pack).

## The tilted PDF

`PDF embeds the tilted boxes as images too` asserted `tiltedBytes > untiltedBytes * 1.5`, a weight proxy for "PDF took the per-box raster branch rather than keeping the AABB path". The proxy was calibrated against the jsPDF writer this shell carried until 2026-09-11 and has no room left under the pdf-lib writer, which Flate-compresses each embed (989 B and 1315 B for the two cards) against an untilted baseline of 6.5 KB that is 5.4 KB of content-independent boilerplate - a 2336 B sRGB profile and a 3058 B XMP packet, written by the PDF/X pass for every export. What remains of the ratio only asks how well a solid-colour card's antialiased edges happen to deflate on the host: **1.78 on macOS, 1.48 on the Linux runner**. The picture itself was never wrong; both platforms embed both rasters.

The case now asks the file the question the ratio stood in for, and asks it exactly: one colour image XObject per tilted box, none at all in the untilted render, and a strict inequality on the sizes with no magic factor. That is stronger than the ratio, not weaker - a ratio passes on any bloat, and would also pass an implementation that embedded one image, or embedded them upright.

## Two things to know before merging

- **`tests/expected-skips.json` is deliberately unchanged.** Its 149 `no Chromium` entries are now stale, but the documented refresh (`tests/README.md`) is `check:skip-identities --write` over every shard's uploaded `test-skips-*` report, and those cannot be produced off a Ubuntu runner - a local write would stamp a macOS-shaped ledger over all nine shards. Expect the skip-identity step to fail on the first run and regenerate the ledger from its artifacts.
- **`export-format-golden.test.ts` runs in CI for the first time.** Its header said "CI has no Chromium, so not there" about its macOS-generated goldens; that was only true because of the revision mismatch. Its two text-bearing fixtures read Chromium's layout through the platform font backend, so 8 of its 12 golden cases may move on Linux while `linear-gradient` holds. The note now says what to do if they do: generate a Linux set and review the diff, never relax the byte comparison.

## Checks run

| Check | Result |
|---|---|
| `run-test-suite.ts browser` (with `PLAYWRIGHT_BROWSERS_PATH`) | 1231 tests, 1175 pass, 0 fail, 56 skip, 0 "no Chromium" |
| `run-test-suite.ts unit:web` | 7262 tests, 7233 pass, 0 fail, 29 skip |
| `check-code-comment-vernacular.ts` | clean (1109, baseline unchanged) |
| `check-docs-vernacular.ts` | clean |
| `node --test tests/workflow-pins.test.ts` | 2 pass |
| `node --test tests/browser-tier-install.test.ts` | 2 pass |
| `check-changed-lint.ts --all` | 2995 files, no new diagnostics |
| `tsc -p tests/tsconfig.json` | clean |
| `build:sbom` + `build:licenses` + `audit:all --check` | regenerated (committed), inventory complete |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFUV4W9E3Vvtxt78ZBSM2u
