### PR TITLE
First-load gate: one boot chunk, one fetch per file, warming on intent

### DIFF
--- a/scripts/check-bundle-budget.ts
+++ b/scripts/check-bundle-budget.ts
@@ -11,7 +11,7 @@
  * engine + handlebars + ajv back onto the critical path, and nothing would fail.
  *
  * This script re-derives the boot payload straight from the built
- * `dist/index.html` (the entry <script> + every <link rel="modulepreload">) and
+ * `dist/index.html` (every module <script> + every <link rel="modulepreload">) and
  * asserts two things:
  *   1. None of the deliberately-lazied heavy chunks appear on the boot path.
  *   2. The total GZIPPED size of the boot JS stays under a budget.
@@ -140,8 +140,13 @@ try {
   fail(`cannot read ${path.relative(root, indexHtml)} - run \`pnpm run build:web\` first`);
 }
 
-// Collect boot JS: the entry <script type="module" src> and every
+// Collect boot JS: every <script type="module" src> and every
 // <link rel="modulepreload" href>. Only same-origin /assets JS counts.
+//
+// EVERY script, plural, and a build may legitimately carry no preloads at all: since the
+// `web-boot` chunk group (shells/web/vite.config.js) put the whole boot graph in one chunk,
+// vite emits the handful of chunks that graph spans as ordered module scripts rather than
+// one entry plus 96 preload links. The sum below is the same set of bytes either way.
 const bootHrefs = new Set<string>();
 for (const m of html.matchAll(/<script[^>]*\bsrc=["']([^"']+)["']/gi)) {
   const src = m[1];

--- a/shells/web/index.html
+++ b/shells/web/index.html
@@ -115,25 +115,34 @@
        those hints were aimed at is fixed by the slim index below, not by a hint that
        cannot speak this protocol.
 
-       The TOOLS index IS preloaded in its slim form (task 3.8), because that one url
-       is fetched unconditionally - no validator, so no 304 for the hint to defeat -
-       and served must-revalidate, so the warmed cache entry turns the boot fetch into
-       a 304 instead of an 18.9 KB gz download. Only for the visitors who will read it:
-       a repeat visitor paints from their cached copy and main.ts never fetches slim, so
-       a static preload would download a file they never use and log "preload not used"
-       for it. `in` rather than getItem: it answers from the key list without
-       materialising the half-megabyte value. (The one url this can still waste is the
-       first load after a switch to a remote instance - setInstanceBase clears
-       sbt-tool-index, and the base lives in IndexedDB where this script cannot read it,
-       so the hint fetches THIS origin's copy while the app fetches the instance's.) -->
+       The TOOLS index is started early in its slim form (task 3.8), because that one
+       url is fetched unconditionally - no validator, so no 304 for a hint to defeat.
+       It used to be a `<link rel="preload" as="fetch">`, and that hint hit the SAME
+       wall the two above do: the preload key never matched instanceFetch's request,
+       so the warmed HTTP-cache entry was the whole benefit and the body came down
+       twice whenever the app's fetch outran the revalidation (a plain unsigned build
+       served without must-revalidate re-downloaded all 22.7 KB of it; measured by
+       scripts/check-first-load.ts, 2026-09-12). So this starts the REAL fetch instead
+       and parks the promise where catalog/sync.ts's loadSlimToolIndex can adopt it:
+       one request, begun at HTML parse rather than after the boot chunks execute,
+       and its body actually used. Only for the visitors who will read it: a repeat
+       visitor paints from their cached copy and main.ts never asks for slim. `in`
+       rather than getItem: it answers from the key list without materialising the
+       half-megabyte value. Adoption is declined for a remote instance or a loaded
+       pack (the base lives in IndexedDB, which this script cannot read) - that
+       visitor pays this one request and sync.ts fetches the instance's own copy,
+       exactly as the old hint behaved. A key-pinned release never reaches slim at
+       all (catalog/integrity.ts), so vite.config.js's slimIndexWarm() strips this
+       whole script from such a build rather than fetching a file nothing reads. -->
   <script>
     (() => {
       try {
         if ('sbt-tool-index' in localStorage) return;   // cached index → main.ts never fetches slim
-        var l = document.createElement('link');
-        l.rel = 'preload'; l.as = 'fetch'; l.href = '/catalog/tools/index.slim.json';
-        document.head.appendChild(l);
-      } catch (e) { /* storage blocked - the fetch just starts at boot instead */ }
+        var u = '/catalog/tools/index.slim.json';
+        var p = fetch(u, { credentials: 'same-origin' });
+        p.catch(function () { /* offline - loadSlimToolIndex falls back to the full index */ });
+        (window.__lollyBootFetch = window.__lollyBootFetch || {})[u] = p;
+      } catch (e) { /* storage or fetch blocked - the fetch just starts at boot instead */ }
     })();
   </script>
   <link rel="stylesheet" href="/src/styles/app.css" />

--- a/shells/web/src/README.md
+++ b/shells/web/src/README.md
@@ -10,17 +10,17 @@ Roughly 529,000 lines of TypeScript, tests included, and 46,000 lines of CSS.
 | Directory | Source | Tests | CSS |
 |---|---|---|---|
 | `views/` | 257 files, 144,643 lines | 136 files, 52,360 lines | 3 files, 193 lines |
-| `lib/` | 489 files, 112,101 lines | 296 files, 58,721 lines | 10 files, 1,256 lines |
-| `bridge/` | 129 files, 45,399 lines | 85 files, 20,074 lines | none |
+| `lib/` | 489 files, 112,146 lines | 296 files, 58,721 lines | 10 files, 1,256 lines |
+| `bridge/` | 129 files, 45,466 lines | 85 files, 20,074 lines | none |
 | `components/` | 64 files, 20,928 lines | 28 files, 9,514 lines | 8 files, 611 lines |
 | `collab/` | 20 files, 13,525 lines | 22 files, 14,131 lines | none |
 | `pro/` | 22 files, 8,386 lines | 11 files, 1,738 lines | 3 files, 1,226 lines |
 | `org/` | 19 files, 6,020 lines | 15 files, 4,008 lines | none |
-| `catalog/` | 2 files, 848 lines | 1 file, 86 lines | none |
+| `catalog/` | 2 files, 859 lines | 1 file, 86 lines | none |
 | `ext/` | 2 files, 136 lines | 1 file, 86 lines | none |
 | `styles/` | none | 4 files, 857 lines | 81 files, 42,758 lines |
 
-Plus 44 `.ts`/`.js` files at the top level of `src/`, 14,967 lines all told, of which 19 are tests and 3 are ambient declarations. `main.ts` is 2,013 of that.
+Plus 45 `.ts`/`.js` files at the top level of `src/`, 15,057 lines all told, of which 20 are tests and 3 are ambient declarations. `main.ts` is 2,051 of that.
 <!-- web-src-dirs:end -->
 
 ## How do I find a feature

--- a/shells/web/src/boot-warm-fetch.test.ts
+++ b/shells/web/src/boot-warm-fetch.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+/**
+ * The pre-paint warm fetch in index.html, and the two things that depend on its shape.
+ *
+ * index.html starts the slim tool index's request at HTML parse and parks the promise on
+ * `window.__lollyBootFetch[<path>]`; catalog/sync.ts's loadSlimToolIndex adopts it by that
+ * exact path string. Nothing at runtime notices if the two drift: the adopt lookup simply
+ * misses, sync.ts fetches normally, and the cold load quietly pays for the same file twice
+ * again - which is the regression scripts/check-first-load.ts caught in the first place,
+ * and it only runs against a deployment.
+ *
+ * The third assertion is about the build: vite.config.js's slimIndexWarm() strips the whole
+ * script from a key-pinned release (which never reads a slim index) and THROWS when its
+ * regex matches nothing, so a reworded script would fail the release build. Checking the
+ * match here means that failure shows up at commit time instead.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SLIM_WARM_SCRIPT } from '../vite.config.js';
+
+const webDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const html = readFileSync(path.join(webDir, 'index.html'), 'utf8');
+const syncSrc = readFileSync(path.join(webDir, 'src/catalog/sync.ts'), 'utf8');
+
+/** The one path both sides have to spell identically. */
+const SLIM_PATH = '/catalog/tools/index.slim.json';
+
+test('index.html starts the slim-index fetch and parks it for adoption', () => {
+  const script = html.match(SLIM_WARM_SCRIPT)?.[0];
+  assert.ok(script, 'no warm script in index.html - slimIndexWarm() would throw on a release build');
+  assert.match(script, /fetch\(/, 'the warm must be a real fetch, not a preload hint a fetch cannot adopt');
+  assert.match(script, /__lollyBootFetch/, 'the promise has to be parked where adoptBootFetch looks');
+  assert.ok(script.includes(`'${SLIM_PATH}'`), `the warm must name ${SLIM_PATH}`);
+  assert.match(script, /'sbt-tool-index' in localStorage/, 'only visitors with no cached index ask for this file');
+});
+
+test('loadSlimToolIndex adopts the boot fetch by the same path', () => {
+  assert.match(syncSrc, /adoptBootFetch\(slimPath\)/, 'loadSlimToolIndex must try the adoption first');
+  // sync.ts builds the path from CATALOG_BASE; check the two compose to the same string.
+  const base = syncSrc.match(/const CATALOG_BASE = '([^']+)'/)?.[1];
+  assert.ok(base, 'CATALOG_BASE not found in catalog/sync.ts');
+  assert.equal(`${base}/tools/index.slim.json`, SLIM_PATH);
+});
+
+test('the warm script is the only thing in index.html that names the slim index', () => {
+  const hits = html.split(SLIM_PATH).length - 1;
+  assert.equal(hits, 1, 'a second reference would be a second request the strip does not remove');
+});

--- a/shells/web/src/bridge/assets.ts
+++ b/shells/web/src/bridge/assets.ts
@@ -271,6 +271,22 @@ export interface AssetsApiOptions {
 }
 
 export function createAssetsAPI(db: AssetsDb, opts: AssetsApiOptions = {}) {
+  // In-flight fetch-and-cache work, keyed by blob key. Two callers wanting the
+  // same asset format at the same moment share ONE network request: on a cold
+  // load the tokens bridge reads brand.json while catalog/sync.ts's core prefetch
+  // is walking the same tier, and each checking "is it cached yet?" before the
+  // other had written anything downloaded the file twice (measured by
+  // scripts/check-first-load.ts, 2026-09-12). Cleared when the work settles, so a failed fetch is retried
+  // rather than a rejected promise being replayed for the life of the page.
+  const inFlight = new Map<string, Promise<Blob>>();
+  const fetchAndCacheOnce = (meta: AssetMetaRecord, format: AssetFormat, blobKey: string): Promise<Blob> => {
+    const pending = inFlight.get(blobKey);
+    if (pending) return pending;
+    const started = fetchAndCache(meta, format, blobKey, db)
+      .finally(() => { inFlight.delete(blobKey); });
+    inFlight.set(blobKey, started);
+    return started;
+  };
   const api = {
     async resolveProvider(ref: { provider: string; scope: string; path: string }): Promise<AssetRef | null> {
       if (ref.provider === 'catalog' || ref.provider === 'library') {
@@ -368,7 +384,7 @@ export function createAssetsAPI(db: AssetsDb, opts: AssetsApiOptions = {}) {
         if (!blob) {
           if (historical) throw new Error(`Asset version unavailable: ${id} (${version})`);
           if (meta.tier === 'on-demand') {
-            blob = await fetchAndCache(meta, format, blobKey, db);
+            blob = await fetchAndCacheOnce(meta, format, blobKey);
           } else {
             throw new Error(`Asset not cached: ${id} (tier: ${meta.tier})`);
           }
@@ -907,12 +923,46 @@ export function createAssetsAPI(db: AssetsDb, opts: AssetsApiOptions = {}) {
     },
 
     /**
+     * Internal: make sure ONE format's bytes are on device, sharing any fetch
+     * already in flight for them. The single fetch-and-cache path: catalog/sync.ts's
+     * core prefetch walks the index and calls this per format, and _getBlob's
+     * `fetchIfMissing` reaches the same work for a reader that needs the bytes now.
+     * Both used to fetch independently, which downloaded a file twice whenever the
+     * two overlapped (see the inFlight note above).
+     *
+     * Resolves null when the bytes are already cached - nothing was fetched. Throws
+     * AssetChecksumError on tampered bytes, and whatever the transport threw on an
+     * unreachable file; the caller decides which of those is worth saying out loud.
+     */
+    async _ensureBlob(meta: AssetMetaRecord, format: AssetFormat): Promise<Blob | null> {
+      const blobKey = `${meta.id}:${format.format}:${meta.version}`;
+      if ((await db.get('asset-blob', blobKey)) !== undefined) return null;
+      return await fetchAndCacheOnce(meta, format, blobKey);
+    },
+
+    /**
      * Internal: the raw cached Blob for an asset, without minting an object URL.
      * Used by callers that just want the bytes (e.g. tokens.loadDoc reading a
      * JSON document) so they don't pin an unused URL in OBJECT_URL_CACHE.
      * Resolves on-demand tiers the same way get() does. Returns null if absent.
+     *
+     * `fetchIfMissing` extends that fetch-and-cache fallback to any tier - for a
+     * caller that needs the bytes NOW and would otherwise fetch the file itself.
+     * Opt-in rather than the default: a core-tier asset is normally already on
+     * device (catalog/sync.ts prefetches the whole tier on idle), and a caller that
+     * is happy to wait for that must keep answering null rather than pulling bytes
+     * onto the first-paint path. The one caller is bridge/tokens.ts, whose read
+     * happens BEFORE that idle prefetch on a cold load: without this it fetched
+     * brand.json itself, cached nothing, and the prefetch then downloaded the same
+     * file a second time (measured by scripts/check-first-load.ts, 2026-09-12).
+     * Going through fetchAndCache means those bytes are checksum-verified and
+     * stored under the same id:format:version key the prefetch checks, so the
+     * second download is skipped instead of deduplicated after the fact.
      */
-    async _getBlob(id: string, opts: { format?: string; version?: string } = {}): Promise<Blob | null> {
+    async _getBlob(
+      id: string,
+      opts: { format?: string; version?: string; fetchIfMissing?: boolean } = {},
+    ): Promise<Blob | null> {
       // `user/...` ids live in the user-assets store as one already-resolved
       // blob (no format/version keying). Mirror get()'s resolution order so
       // callers like the tokens bridge can read a user-installed document by id.
@@ -926,8 +976,8 @@ export function createAssetsAPI(db: AssetsDb, opts: AssetsApiOptions = {}) {
       const version = opts.version ?? meta.version;
       const blobKey = `${id}:${format.format}:${version}`;
       let blob = await db.get('asset-blob', blobKey);
-      if (!blob && version === meta.version && meta.tier === 'on-demand') {
-        blob = await fetchAndCache(meta, format, blobKey, db);
+      if (!blob && version === meta.version && (meta.tier === 'on-demand' || opts.fetchIfMissing)) {
+        blob = await fetchAndCacheOnce(meta, format, blobKey);
       }
       return blob ?? null;
     },
@@ -1422,6 +1472,12 @@ async function sriForBlob(blob: Blob): Promise<string> {
   return `sha256-${btoa(bin)}`;
 }
 
+/** Tampered or corrupt bytes, as distinct from an unreachable file. Its own class
+ *  so a caller can tell the two apart without matching on a message: catalog/sync.ts's
+ *  prefetch warns about this one and stays quiet about a fetch that simply failed,
+ *  which on an offline boot is every asset in the tier. */
+export class AssetChecksumError extends Error {}
+
 /**
  * Verify freshly-fetched bytes against the catalog checksum, throwing on a real
  * mismatch (tampered/corrupt download). No-ops when the format carries no
@@ -1434,7 +1490,7 @@ export async function verifyAssetChecksum(blob: Blob, format: AssetFormat | unde
   if (!format?.checksum || !globalThis.crypto?.subtle) return;
   const actual = await sriForBlob(blob);
   if (actual !== format.checksum) {
-    throw new Error(
+    throw new AssetChecksumError(
       `Asset checksum mismatch for ${format.url}: expected ${format.checksum}, got ${actual}`,
     );
   }

--- a/shells/web/src/bridge/tokens.ts
+++ b/shells/web/src/bridge/tokens.ts
@@ -89,7 +89,11 @@ interface TokensAssetMeta {
  *  read the SHIPPED brand's lock flag, which a user asset must not shadow. */
 interface TokensHost {
   assets: {
-    _getBlob(id: string): Promise<Blob | null>;
+    /** `fetchIfMissing` asks the asset bridge to fetch-and-cache a synced asset
+     *  whose blob is not on device yet, instead of answering null - see
+     *  readAssetDoc. Declared optional in shape (a stub may take one argument);
+     *  every real caller passes it. */
+    _getBlob(id: string, opts?: { fetchIfMissing?: boolean }): Promise<Blob | null>;
     _findMetaByType(type: string, opts?: { catalogOnly?: boolean }): Promise<TokensAssetMeta | null>;
   };
   /** Optional: the host log, used once per unreadable version (see forVersion).
@@ -608,10 +612,17 @@ export function createTokensAPI(host: TokensHost): WebTokensAPI {
     // 1) The core-prefetched blob - present and offline-safe once boot sync ran.
     //    Read the bytes directly; minting/fetching an object URL just to re-parse
     //    in-memory JSON would pin an unused URL in the asset bridge's cache.
+    //    `fetchIfMissing`: on a COLD load this read runs before the idle core
+    //    prefetch, so the blob is not there yet. Letting the asset bridge fetch it
+    //    means the bytes are checksum-verified and stored under the key that
+    //    prefetch checks, so the prefetch skips the file instead of downloading it
+    //    again - the duplicate brand.json fetch scripts/check-first-load.ts caught
+    //    on 2026-09-12. Step 2 below stays for the case this cannot serve: an asset
+    //    whose metadata has not synced yet (nothing to fetch BY), or no IndexedDB.
     try {
-      const blob = await host.assets._getBlob(asset.id);
+      const blob = await host.assets._getBlob(asset.id, { fetchIfMissing: true });
       if (blob) return JSON.parse(await blob.text());
-    } catch { /* not cached yet - fall through to a direct fetch */ }
+    } catch { /* not cached, or the fetch/checksum failed - fall through */ }
     // 2) Direct fetch of the asset's file - first load, before the blob is cached.
     try {
       const url = asset.formats[0]?.url;

--- a/shells/web/src/catalog/sync.ts
+++ b/shells/web/src/catalog/sync.ts
@@ -17,7 +17,7 @@
  * indicator).
  */
 
-import { verifyAssetChecksum } from '../bridge/assets.ts';
+import { AssetChecksumError } from '../bridge/assets.ts';
 import { assertToolIndexIntegrity, getToolIntegrity } from './integrity.ts';
 import { currentLang, t } from '../i18n.ts';
 import { pinnedAssetIds, refreshPinnedToolFiles } from '../lib/offline-pins.ts';
@@ -27,11 +27,11 @@ import { pinnedAssetIds, refreshPinnedToolFiles } from '../lib/offline-pins.ts';
 // they are the only two edges to a ~7.9 KB module that also drags the upscale/matte
 // model tables along. Both call sites are async, so the import is invisible.
 const offlineManager = () => import('../lib/offline-manager.ts');
-import { initInstanceBase, instanceFetch, instancePath, usesBrowserCors } from '../lib/instance.ts';
+import { adoptBootFetch, initInstanceBase, instanceFetch, instancePath, usesBrowserCors } from '../lib/instance.ts';
 
 /** One resolvable file for a catalog asset (an entry in an asset's `formats`).
  *  Structurally matches the bridge's AssetFormat so it flows into
- *  verifyAssetChecksum unchanged. */
+ *  _ensureBlob unchanged. */
 interface AssetFormat {
   format: string;
   url: string;
@@ -136,6 +136,9 @@ interface SyncHost {
     _pruneStale(assets: AssetMetaRecord[], sessionRefs: Set<string>, keepIds?: Set<string>): Promise<{ blobs: number; meta: number }>;
     _hasBlob(key: string): Promise<boolean>;
     _cacheBlob(key: string, blob: Blob): Promise<unknown>;
+    /** Fetch-and-cache one format's bytes, sharing any download already in
+     *  flight for them; null when they are already on device. See prefetchAsset. */
+    _ensureBlob(meta: AssetMetaRecord, format: AssetFormat): Promise<Blob | null>;
   };
   state: { _getAssetRefs(): Promise<Set<string>> };
 }
@@ -323,16 +326,17 @@ let slimPromise: Promise<ToolIndex | null> | null = null;
  * cache. The file is served must-revalidate (vercel.json) and is small enough that
  * a revalidation round-trip is the whole cost.
  *
- * That is also the one reason index.html may preload THIS url and not the two
+ * That is also the one reason index.html may start THIS url early and not the two
  * conditional ones above: with no validator in play there is no 304 for an
- * unconditional hint to defeat. The preloaded response is still never ADOPTED by
- * this fetch (conditionalFetch's note has the mechanism) - what the hint buys is
- * a warm HTTP-cache entry, so the boot-time request below is answered by a
- * must-revalidate 304 off disk instead of an 18.9 KB gz download. It is worth
- * the round-trip only because the hint starts at HTML parse and this call starts
- * after the boot chunks execute; in the window where boot outruns the hint the
- * two requests are independent and the body is fetched twice, which is why the
- * inline script gates it to visitors with no cached index at all.
+ * unconditional early request to defeat. It starts the real fetch and parks the
+ * promise for adoptBootFetch (lib/instance.ts) to hand back here, so the request
+ * begins at HTML parse instead of after the boot chunks execute and the body is
+ * used rather than downloaded twice. It was a `<link rel="preload" as="fetch">`
+ * until 2026-09-12, and a preloaded response is never ADOPTED by this fetch
+ * (conditionalFetch's note has the mechanism) - all that hint bought was a warm
+ * HTTP-cache entry, and where the boot fetch outran the revalidation the whole
+ * 22.7 KB came down a second time. The gate is unchanged: only visitors with no
+ * cached index at all, since nobody else asks for this file.
  *
  * Resolves null - never throws - on anything unusual: an offline/failed fetch, a
  * deployment that predates the file, an empty index, or a build that pins a catalog
@@ -347,7 +351,12 @@ export function loadSlimToolIndex(): Promise<ToolIndex | null> {
       // same memoised promise, so this costs one shared IndexedDB read, not two.
       await initInstanceBase();
       if (await getToolIntegrity()) return null;
-      const resp = await instanceFetch(instancePath(`${CATALOG_BASE}/tools/index.slim.json`));
+      // index.html's pre-paint script already started this exact request on a cold
+      // visit (see its slim-index note): adopt that response rather than making a
+      // second one. Null when there is nothing to adopt - a repeat visitor, a
+      // release build with the script stripped, a remote instance or a loaded pack.
+      const slimPath = `${CATALOG_BASE}/tools/index.slim.json`;
+      const resp = await (adoptBootFetch(slimPath) ?? instanceFetch(instancePath(slimPath)));
       if (!resp.ok) return null;
       const index = await resp.json() as ToolIndex;
       if (!Array.isArray(index?.tools) || !index.tools.length) return null;
@@ -509,19 +518,21 @@ async function syncAssets(host: SyncHost): Promise<void> {
 async function prefetchAsset(host: SyncHost, meta: AssetMetaRecord, signal?: AbortSignal): Promise<void> {
   for (const fmt of meta.formats) {
     signal?.throwIfAborted();
-    const key = `${meta.id}:${fmt.format}:${meta.version}`;
-    if (await host.assets._hasBlob(key)) continue;
-    const resp = await instanceFetch(fmt.url, signal ? { signal } : undefined);
-    if (!resp.ok) continue;
-    const blob = await resp.blob();
+    // The asset bridge owns the fetch: it checks the cache, verifies the checksum,
+    // stores the blob, and - the reason this is not a fetch of its own any more -
+    // shares a download already in flight for the same bytes. A page reader that
+    // needs a core asset before this idle pass reaches it (bridge/tokens.ts and
+    // brand.json) used to make its own request, and the two overlapped.
     try {
-      await verifyAssetChecksum(blob, fmt);
+      await host.assets._ensureBlob(meta, fmt);
     } catch (e) {
-      // Corrupt/tampered bytes - skip caching rather than storing a bad blob.
+      // Corrupt/tampered bytes are worth saying out loud; skip caching rather than
+      // storing a bad blob. Anything else is a file we could not reach - on an
+      // offline boot that is every asset in the tier, so it rethrows to the
+      // allSettled above and stays out of the console, exactly as it did before.
+      if (!(e instanceof AssetChecksumError)) throw e;
       host.log('warn', `Skipping prefetch (checksum mismatch): ${fmt.url}`, { error: String(e) });
-      continue;
     }
-    await host.assets._cacheBlob(key, blob);
   }
 }
 

--- a/shells/web/src/lib/instance.ts
+++ b/shells/web/src/lib/instance.ts
@@ -226,6 +226,51 @@ export function instancePath(p: string): string {
   return p.startsWith('/') ? base + p : `${base}/${p}`;
 }
 
+declare global {
+  interface Window {
+    /** Fetches index.html's pre-paint script started, keyed by root-relative
+     *  path - see adoptBootFetch. Optional, and every entry is optional: the
+     *  script is gated (and a release build strips it entirely), so the usual
+     *  state is that this object does not exist. */
+    __lollyBootFetch?: Record<string, Promise<Response> | undefined>;
+  }
+}
+
+/**
+ * A fetch index.html's pre-paint script already started for this path, or null.
+ *
+ * The boot script (see the slim-index note in index.html) begins one request at
+ * HTML parse time - well before the boot chunks execute - and parks the promise
+ * on `window.__lollyBootFetch` keyed by root-relative path. This is the only way
+ * to ADOPT it: a `<link rel="preload" as="fetch">` hint cannot be, because the
+ * preload key it creates never matches the request instanceFetch makes (mode,
+ * credentials and the x-lolly-client header all differ - the full trace is in
+ * that same index.html note), so the body came down twice.
+ *
+ * Declines when this device points at a remote instance or has a pack loaded:
+ * both answer the SAME path with a different body, and the boot script - which
+ * cannot read IndexedDB - fetched this origin's copy. The caller then fetches
+ * normally and that one early request is wasted, which is exactly what the
+ * preload hint did for those visitors too.
+ *
+ * The adopted request carries no x-lolly-client - markup has no way to set a
+ * header - and that costs nothing here: the value is shell kind plus engine
+ * version, plus an install tag only a signed-in member session holds, and by the
+ * time org/index.ts turns that tag on this fetch is long finished. The one case
+ * where the header routes anything is a remote instance, which is exactly the
+ * case adoption declines.
+ *
+ * One-shot: the entry is dropped on the way out, so a retry re-fetches rather
+ * than replaying a failed response.
+ */
+export function adoptBootFetch(path: string): Promise<Response> | null {
+  const pending = window.__lollyBootFetch?.[path];
+  if (!pending) return null;
+  delete window.__lollyBootFetch?.[path];
+  if (base || packActive()) return null;
+  return pending;
+}
+
 /**
  * fetch() for instance-base traffic: a bounded native command for cross-origin
  * URLs under Tauri (CORS-free, HTTPS/public-address checked in Rust),

--- a/shells/web/src/main.ts
+++ b/shells/web/src/main.ts
@@ -1576,35 +1576,73 @@ async function boot(): Promise<void> {
   // import() promises are cached, so the later route reuses these.
   const warmTool = (): void => { void import('./views/tool.ts').catch(() => {}); };
 
-  // The TOOL view is special: it statically pulls the render engine (createRuntime +
+  // The TOOL path is special: it statically pulls the render engine (createRuntime +
   // Handlebars + Ajv + export, ~170 KB gz). That used to sit on the boot preload - moving
-  // it off made the gallery boot lean, but a cold first tool-open now shows a "Loading…"
-  // state while those chunks arrive. So warm it PROMPTLY (tight idle timeout wins the slot
-  // even while the featured row is rendering), not on deep idle - the cold window shrinks
-  // from ~1.6s to <0.6s. Lolly is a tool app; the tool engine being warm matters most.
-  if (typeof requestIdleCallback === 'function') requestIdleCallback(warmTool, { timeout: 600 });
-  else setTimeout(warmTool, 200);
+  // it off made the gallery boot lean, but a cold first tool-open then showed a "Loading…"
+  // state while those chunks arrived. So something is warmed PROMPTLY (tight idle timeout
+  // wins the slot even while the featured row is rendering), not on deep idle - the cold
+  // window shrinks from ~1.6s to <0.6s. Lolly is a tool app; the tool engine being warm
+  // matters most.
+  //
+  // What gets warmed unconditionally is the ENGINE, not the whole view. Those 170 KB are
+  // lib/mount-runtime.ts's static graph - the chokepoint every runtime in this shell goes
+  // through. views/tool.ts pulls that AND ~145 more chunks of view code, a few hundred
+  // bytes each: nothing in bytes, but 145 connections opened on every cold visit before
+  // the visitor has touched anything, which is what scripts/check-first-load.ts counts and
+  // what no byte budget can see. The view itself warms on intent below instead, where a
+  // pointerdown still puts it in flight ahead of the click that navigates.
+  const warmEngine = (): void => { void import('./lib/mount-runtime.ts').catch(() => {}); };
+  if (typeof requestIdleCallback === 'function') requestIdleCallback(warmEngine, { timeout: 600 });
+  else setTimeout(warmEngine, 200);
 
-  // Belt-and-suspenders: warm the engine the instant a tool link is hovered or pressed, so
-  // even a tap inside that <0.6s window opens warm. Capture-phase, one-shot (import() caches),
-  // and it fires ahead of the click that navigates. Covers gallery tiles, the featured row,
-  // catalog, search results - anything linking to a tool - with one delegated listener.
+  // Warm a view the instant a link to it is hovered or pressed. Capture-phase, one-shot
+  // per target (import() caches), and it fires ahead of the click that navigates. Covers
+  // gallery tiles, the featured row, catalog, search results - anything linking to a tool -
+  // plus the three secondary routes, which used to be three unconditional deep-idle
+  // imports. Those read as free and are, in bytes; in connections they were another ~32 on
+  // every cold visit for views most visitors never open.
+  //
+  // A Map, not an object literal: the key comes off a link in the page, and an object
+  // would answer `constructor` and friends from its prototype.
+  const warmSecondary = new Map<string, () => void>();
+  {
+    const dashboard = (): void => { void import('./views/dashboard.ts').catch(() => {}); };
+    const projects = (): void => { void import('./views/projects.ts').catch(() => {}); };
+    const catalog = (): void => { void import('./views/catalog.ts').catch(() => {}); };
+    // Every hash spelling parseRoute() below accepts for these three, including the
+    // ones that land via a redirect (#/b and #/brand → the dashboard's brand tab).
+    for (const k of ['d', 'dashboard', 'b', 'brand', 'platform', 'capabilities']) warmSecondary.set(k, dashboard);
+    warmSecondary.set('p', projects);
+    for (const k of ['c', 'catalog']) warmSecondary.set(k, catalog);
+  }
+  /** The route a hover/press is aimed at: the first path segment of the nearest
+   *  link's hash (an `<a href>` or a jelly-button's `data-href`), else a
+   *  `[data-route]` control's own value. Null when the target is neither. */
+  const intentRoute = (el: Element): string | null => {
+    const link = el.closest<HTMLElement>('a[href], [data-href]');
+    const href = link?.getAttribute('href') ?? link?.getAttribute('data-href') ?? '';
+    const hash = href.slice(href.indexOf('#') + 1);
+    const seg = href.includes('#') ? hash.split('?')[0]?.split('/').filter(Boolean)[0] : undefined;
+    return seg ?? el.closest<HTMLElement>('[data-route]')?.dataset.route ?? null;
+  };
+  const views = new Set(warmSecondary.values()).size;
+  const warmedViews = new Set<() => void>();
   let toolWarmed = false;
   const warmOnIntent = (e: Event): void => {
-    if (toolWarmed) return;
-    if ((e.target as HTMLElement | null)?.closest?.('a[href*="tool/"]')) { toolWarmed = true; warmTool(); }
+    const el = e.target instanceof Element ? e.target : null;
+    if (!el) return;
+    if (!toolWarmed && el.closest?.('a[href*="tool/"]')) { toolWarmed = true; warmTool(); }
+    const route = intentRoute(el);
+    const warm = route ? warmSecondary.get(route) : undefined;
+    if (warm && !warmedViews.has(warm)) { warmedViews.add(warm); warm(); }
+    // Once there is nothing left to warm, stop walking ancestors on every pointer
+    // move: these fire for the life of the page and the work is finished.
+    if (!toolWarmed || warmedViews.size < views) return;
+    document.removeEventListener('pointerover', warmOnIntent, { capture: true });
+    document.removeEventListener('pointerdown', warmOnIntent, { capture: true });
   };
   document.addEventListener('pointerover', warmOnIntent, { capture: true, passive: true });
   document.addEventListener('pointerdown', warmOnIntent, { capture: true, passive: true });
-
-  // The other route chunks are light - deep idle is fine.
-  if (typeof requestIdleCallback === 'function') {
-    requestIdleCallback(() => {
-      import('./views/dashboard.ts').catch(() => {});
-      import('./views/projects.ts').catch(() => {});
-      import('./views/catalog.ts').catch(() => {});
-    });
-  }
 
   // Re-render on any route change. hashchange covers legacy #/… links and external
   // deep links; popstate covers History-API back/forward across /t/<id> tool entries;

--- a/shells/web/vite.config.js
+++ b/shells/web/vite.config.js
@@ -513,6 +513,39 @@ export function stripModelCandidates() {
   };
 }
 
+// Strip index.html's slim-index warm fetch from a build that pins a catalog signing
+// key. That script starts the /catalog/tools/index.slim.json request at HTML parse so
+// catalog/sync.ts can adopt it (see the note beside it in index.html) - but a key-pinned
+// release never reads the slim index at all: loadSlimToolIndex returns null the moment
+// getToolIntegrity() answers, because a slim index carries no signature of its own and a
+// verified build must not paint from unverified bytes. Left in, the script downloaded
+// 19 KB gz on every cold production load for a file nothing would read. Reads the env var
+// rather than VITE_CATALOG_TRUST_MODE because the var IS the pin catalog/integrity.ts
+// keys off; the two are cross-checked at the top of this file.
+//
+// Throws when it matches nothing, on the rule the brandChrome font strip learned the hard
+// way: a strip that silently no-ops ships the thing it was meant to remove.
+
+/** The warm script in index.html. Exported so src/boot-warm-fetch.test.ts can assert it
+ *  still matches the real file - the throw above is the wrong place to learn it does not. */
+export const SLIM_WARM_SCRIPT = /\n\s*<script>\s*\(\(\) => \{[\s\S]*?index\.slim\.json[\s\S]*?<\/script>/;
+
+function slimIndexWarm() {
+  const pinned = !!process.env.VITE_CATALOG_PUBLIC_KEY_JWK?.trim();
+  return {
+    name: 'lolly-slim-index-warm',
+    apply: 'build',
+    transformIndexHtml(html, ctx) {
+      if (!pinned || !(ctx?.path ?? '').endsWith('index.html')) return html;
+      const stripped = html.replace(SLIM_WARM_SCRIPT, '');
+      if (stripped === html) {
+        throw new Error('vite.config: slimIndexWarm found no warm script in index.html - has it been renamed or removed?');
+      }
+      return stripped;
+    },
+  };
+}
+
 // The `new URL('<name>.wasm', import.meta.url)` sites inside onnxruntime-web's
 // emscripten glue. Anchored on the `ort-wasm-` prefix, NOT on `.wasm`: the same
 // pattern in harfbuzzjs is what emits /assets/harfbuzz-*.wasm (390 KB, the shaper
@@ -627,7 +660,7 @@ export default defineConfig({
   // deterministic either way). fontPreloadUrls' position here is cosmetic - it
   // declares order:'post', so it runs after brandChrome() wherever it sits, and
   // ortWasmFromPublic's is too - it declares enforce:'pre'.
-  plugins: [serveRepoStatic(), brandChrome(), fontPreloadUrls(), ortWasmFromPublic(), stripModelCandidates(), precacheManifest()],
+  plugins: [serveRepoStatic(), brandChrome(), fontPreloadUrls(), slimIndexWarm(), ortWasmFromPublic(), stripModelCandidates(), precacheManifest()],
   // The Neurospicy player + video music-bed exporter render ZzFXM songs in a
   // module worker (src/lib/zzfxm-worker.ts, which ESM-imports the engine). Emit
   // it as an ES module so the import graph survives the build unchanged.
@@ -826,6 +859,21 @@ export default defineConfig({
             // 2026-09-11: -0.2 KB gz off the preload set, and the escaper keeps its
             // own file (primitive-guards.test.ts pins the implementation there).
             { name: 'web-utils', test: /shells\/web\/src\/(utils\.ts|lib\/util\/escape\.ts)$/, minSize: 0, minShareCount: 1 },
+            // EVERYTHING ELSE ON THE BOOT PATH, in one chunk. `$initial` is rolldown's
+            // built-in tag for "statically imported by an entry, or on its static
+            // dependency chain" - exactly the set dist/index.html modulepreloads. Left
+            // to default chunking that set came out as 96 files, ~50 of them under
+            // 600 B gz: one request, one preload link and one chunk preamble each, for
+            // a boot payload whose bytes are dominated by four chunks. The byte total
+            // is unchanged (the same modules, the same graph) but the browser opens two
+            // connections before first paint instead of 97, which is what
+            // scripts/check-first-load.ts counts and what no byte budget can see.
+            // LAST among the groups so every deliberate split above still wins: an
+            // engine leaf isolated up there stays isolated, and a chunk that is NOT on
+            // the boot path (engine-render, handlebars, ajv, the lazy views) is not
+            // `$initial`, so it can never be merged in here - the check-bundle-budget
+            // assertion that those never boot holds by construction.
+            { name: 'web-boot', tags: ['$initial'], minSize: 0, minShareCount: 1 },
           ],
         },
       },


### PR DESCRIPTION
`scripts/check-first-load.ts` fails against production on three of its five assertions, and did before the fold. Reproduced locally against a `LOLLY_PROFILE=lolly-start` build served by `vite preview` (Lighthouse mobile, the same preset the gate uses):

| assertion | before | after | ceiling |
|---|---|---|---|
| request count | **367** | **164** | 250 |
| modulepreloads in served HTML | **96** | **0** | 95 |
| duplicate fetches | **2 URLs** | **0** | 0 |
| total transfer | 0.88 MB | 0.82 MB | 2.0 MB |
| performance score | 0.62 | 0.64 | 0.60 |
| TBT | 262 ms | 297 ms | 800 ms |
| FCP (not gated) | 3.50 s | 2.73 s | - |
| LCP | 14.96 s | 9.61 s | 4.0 s (still red locally, see below) |

Boot JS also drops from **157.1 KB gz to 128.4 KB gz** against the 158 KB `check-bundle-budget.ts` ceiling.

### Requests, by category

| category | before | after |
|---|---|---|
| app JS chunks | 309 | 122 |
| app CSS | 18 | 4 |
| catalog assets (core prefetch) | 9 | 8 |
| tool index | 3 | 2 |
| app fonts | 4 | 4 |
| catalog fonts | 3 | 3 |
| icons | 3 | 3 |
| tool files (featured-row live renders) | 15 | 15 |
| document, manifest, /api/auth/config | 3 | 3 |
| **total** | **367** | **164** |

Nothing the page shows changed: the featured renders, the core-asset prefetch, both tool indexes and every font are fetched exactly as before.

### The four causes

**1. 96 preload links, 97 boot files.** The boot graph was 96 chunks, about 50 of them under 600 B gz - a request, a preload link and a chunk preamble each, for a payload whose bytes live in four files. A `web-boot` group over rolldown's built-in `$initial` tag (which *is* the set `dist/index.html` preloads) merges them. Vite then emits the few chunks that graph spans as ordered module scripts and no preload links. Placed last among the groups, so every deliberate split above it still wins and a chunk that is not on the boot path is not `$initial` and cannot be merged in - the budget script's "no heavy chunks preloaded" assertion holds by construction, and still passes.

**2. `brand.json` fetched twice.** `bridge/tokens.ts` read the brand document before the idle core prefetch got to it, fetched the file itself with `cache: 'no-store'`, and cached nothing - so `catalog/sync.ts` downloaded it again 60 ms later. There is now one fetch-and-cache path: the asset bridge's `_ensureBlob` checks the cache, verifies the checksum, stores the blob, and shares a download already in flight for the same bytes. `prefetchAsset` calls it instead of fetching itself; the tokens read reaches it via `_getBlob(id, { fetchIfMissing: true })`, so those bytes are verified and stored under the key the prefetch checks. A checksum mismatch became its own error class so the prefetch can warn about tampered bytes and stay silent about a file it could not reach - which on an offline boot is every asset in the tier, as it was before.

**3. `index.slim.json` fetched twice.** `index.html` hinted it with `<link rel="preload" as="fetch">`, and a preload key never matches `instanceFetch`'s request - the wall already documented for the two conditional indexes beside it. The hint bought a warm HTTP-cache entry and nothing more, and where the boot fetch outran the revalidation all 22.7 KB came down again. It now starts the real fetch and parks the promise for `adoptBootFetch()`, which `loadSlimToolIndex` adopts: one request, begun at HTML parse instead of after the boot chunks execute, body actually used. Adoption is declined for a remote instance or a loaded pack, which answer that path with different bytes. A key-pinned release never reads a slim index at all (`catalog/integrity.ts`), so `slimIndexWarm()` strips the script from such a build rather than downloading 19 KB gz nothing reads; it throws if it ever matches nothing, and `boot-warm-fetch.test.ts` holds that match, the parked path and sync.ts's adoption at commit time.

**4. 230 chunks of post-paint warming.** `main.ts` warmed four view graphs after first paint - `views/tool.ts` promptly, then dashboard/projects/catalog on deep idle. That is ~90 KB in bytes and 230 connections in practice, opened before the visitor has touched anything. The unconditional warm is now the **engine** rather than the whole view (`lib/mount-runtime.ts`'s static graph is exactly the createRuntime + Handlebars + Ajv ~170 KB gz that comment has always been about), and the views warm **on intent** off the `pointerover`/`pointerdown` listener the tool view already used. A `pointerdown` still puts a view in flight ahead of the click that navigates, and the listeners detach once there is nothing left to warm.

### What I did not do

- **Coarser lazy chunking was tried and rejected.** Merging small shared lazy modules into one chunk gets requests to 132, but the shared bundle is 341-643 KB gz depending on the cut, and a warmed view pulls all of it: transfer went to 1.94 MB and 2.82 MB in the two variants I measured. `entriesAware` avoids the waste in principle and duplicates dependencies in practice (dist grew to 8.2 MB of chunk bytes). Numbers for every variant are in the thread of measurements; none beat the warming fix on bytes.
- **Thresholds are untouched.** Modulepreloads now measure 0 against a ceiling of 95; that can be ratcheted once a deploy confirms it, but not from here.
- **LCP is still red locally** at 9.61 s. It was 14.96 s locally before this change and it is not one of production's failures, so the local number is the single-threaded preview server, not the app. I improved it by a third without chasing it.

### Verified

- `node scripts/check-first-load.ts http://localhost:4181` against the local production build - the table above.
- `node scripts/run-test-suite.ts unit:web` - 7239 pass, 0 fail, 26 skipped (560 files).
- `npx tsc -p shells/web/tsconfig.json --noEmit` and `-p scripts/tsconfig.json` - clean.
- `node scripts/check-bundle-budget.ts` - 128.4 KB gz / 158 KB, no heavy chunks on boot.
- `node scripts/check-changed-lint.ts --all` - no new diagnostics. `node scripts/check-code-comment-vernacular.ts` - clean against baseline.
- A key-pinned build (`VITE_CATALOG_TRUST_MODE=verified` + a key) emits no reference to the slim index in `dist/index.html`.
- Real Chrome against the local build: clean boot ("Lolly ready, 66 tools", no console errors), gallery / `#/tool/qr-code` / `#/c` / `#/d` all mount, and hovering the Dashboard button or a tool tile fetches that view's chunks - the intent warm works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFUV4W9E3Vvtxt78ZBSM2u
